### PR TITLE
TRUE/FALSE ifndef

### DIFF
--- a/libscpi/inc/scpi/types.h
+++ b/libscpi/inc/scpi/types.h
@@ -47,8 +47,12 @@
 extern "C" {
 #endif
 
-#define FALSE false
-#define TRUE true
+#ifndef FALSE
+    #define FALSE 0
+#endif
+#ifndef TRUE
+    #define TRUE (!FALSE)
+#endif
 
     /* basic data types */
     typedef bool bool_t;


### PR DESCRIPTION
avoids conflicting TRUE/FALSE definitions when using scpi source in other projects
