### PR TITLE
New SCPI_ParamChoice function

### DIFF
--- a/libscpi/inc/scpi/error.h
+++ b/libscpi/inc/scpi/error.h
@@ -59,6 +59,7 @@ extern "C" {
 #define SCPI_ERROR_SUFFIX_NOT_ALLOWED   -138
 
 #define SCPI_ERROR_EXECUTION_ERROR      -200
+#define SCPI_ERROR_ILLEGAL_PARAMETER_VALUE	-224
     
 #ifdef	__cplusplus
 }

--- a/libscpi/inc/scpi/parser.h
+++ b/libscpi/inc/scpi/parser.h
@@ -61,6 +61,7 @@ extern "C" {
     bool_t SCPI_ParamString(scpi_t * context, const char ** value, size_t * len, bool_t mandatory);
     bool_t SCPI_ParamText(scpi_t * context, const char ** value, size_t * len, bool_t mandatory);    
     bool_t SCPI_ParamBool(scpi_t * context, bool_t * value, bool_t mandatory);
+    bool_t SCPI_ParamChoice(scpi_t * context, const char * options[], size_t * value, bool_t mandatory);
 
 
 #ifdef	__cplusplus

--- a/libscpi/src/error.c
+++ b/libscpi/src/error.c
@@ -181,6 +181,7 @@ const char * SCPI_ErrorTranslate(int16_t err) {
         case SCPI_ERROR_MISSING_PARAMETER: return "Missing parameter";
         case SCPI_ERROR_INVALID_SUFFIX: return "Invalid suffix";
         case SCPI_ERROR_SUFFIX_NOT_ALLOWED: return "Suffix not allowed";
+        case SCPI_ERROR_ILLEGAL_PARAMETER_VALUE: return "Illegal parameter value";
         default: return "Unknown error";
     }
 }

--- a/libscpi/src/parser.c
+++ b/libscpi/src/parser.c
@@ -617,3 +617,35 @@ bool_t SCPI_ParamBool(scpi_t * context, bool_t * value, bool_t mandatory) {
     return TRUE;
 }
 
+/**
+ * Parse choice parameter
+ * @param context
+ * @param options
+ * @param value
+ * @param mandatory
+ * @return 
+ */
+bool_t SCPI_ParamChoice(scpi_t * context, const char * options[], size_t * value, bool_t mandatory) {
+    const char * param;
+    size_t param_len;
+    size_t res;
+
+    if (!options || !value) {
+        return FALSE;
+    }
+
+    if (!SCPI_ParamString(context, &param, &param_len, mandatory)) {
+        return FALSE;
+    }
+
+	for (res = 0; options[res]; ++res) {
+	    if (matchPattern(options[res], strlen(options[res]), param, param_len)) {
+			*value = res;
+			return TRUE;
+		}
+    }
+
+	SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+    return FALSE;
+}
+


### PR DESCRIPTION
I suggest adding a function to read "choice" parameters. It may be used to handle command like this:

TRIGger:SOURce {BUS|IMMediate|EXTernal}
