### PR TITLE
Support IEEE488.2 packed binary formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ These are the functions, you can use to read command parameters
  - `SCPI_ParamNumber` - read double value with or without units or represented by special number (DEF, MIN, MAX, ...). This function is more universal then SCPI_ParamDouble.
  - `SCPI_ParamText` - read text value - may be encapsuled in ""
  - `SCPI_ParamString` - read unspecified parameter not encapsulated in ""
+ - `SCPI_ParamBinary` - read IEEE488.2 packed binary value - eg #14ABCD
  - `SCPI_ParamBool` - read boolean value (ON, OFF, 0, 1)
  - `SCPI_ParamChoice` - read enumeration value eg. (BUS, IMMediate, EXTernal) defined by parameter
 
@@ -174,6 +175,7 @@ These are the functions, you can use to write command results
  - `SCPI_ResultDouble` - write double value
  - `SCPI_ResultText` - write text value encapsulated in ""
  - `SCPI_ResultString` - directly write string value
+ - `SCPI_ResultBinary` - write data with IEEE488.2 packed binary header prepended
  - `SCPI_ResultBool` - write boolean value
 
 You can use the function `SCPI_NumberToStr` to convert number with units to textual representation and then use `SCPI_ResultString` to write this to the user.

--- a/libscpi/inc/scpi/parser.h
+++ b/libscpi/inc/scpi/parser.h
@@ -54,12 +54,14 @@ extern "C" {
     size_t SCPI_ResultInt(scpi_t * context, int32_t val);
     size_t SCPI_ResultDouble(scpi_t * context, double val);
     size_t SCPI_ResultText(scpi_t * context, const char * data);
+    size_t SCPI_ResultBinary(scpi_t * context, const char * data, const size_t data_len);
     size_t SCPI_ResultBool(scpi_t * context, scpi_bool_t val);
 
     scpi_bool_t SCPI_ParamInt(scpi_t * context, int32_t * value, scpi_bool_t mandatory);
     scpi_bool_t SCPI_ParamDouble(scpi_t * context, double * value, scpi_bool_t mandatory);
     scpi_bool_t SCPI_ParamString(scpi_t * context, const char ** value, size_t * len, scpi_bool_t mandatory);
     scpi_bool_t SCPI_ParamText(scpi_t * context, const char ** value, size_t * len, scpi_bool_t mandatory);    
+    scpi_bool_t SCPI_ParamBinary(scpi_t * context, const void ** value, size_t * len, scpi_bool_t mandatory);
     scpi_bool_t SCPI_ParamBool(scpi_t * context, scpi_bool_t * value, scpi_bool_t mandatory);
     scpi_bool_t SCPI_ParamChoice(scpi_t * context, const char * options[], int32_t * value, scpi_bool_t mandatory);
 


### PR DESCRIPTION
I know you already have this support in your experimental branch, but this adds it to the currently working base version.  No tests I'm afraid, there were no existing tests for params/results to follow along from.