### PR TITLE
Minor fix

### DIFF
--- a/libscpi/inc/scpi/config.h
+++ b/libscpi/inc/scpi/config.h
@@ -98,6 +98,25 @@ extern "C" {
 #endif
 
 #if HAVE_DTOSTRE
+
+char * dtostre(
+	double __val,
+	char * __s,
+	unsigned char __prec,
+	unsigned char __flags);
+
+#ifndef DTOSTRE_ALWAYS_SIGN
+#define	DTOSTRE_ALWAYS_SIGN 0x01
+#endif
+
+#ifndef DTOSTR_PLUS_SIGN
+#define	DTOSTR_PLUS_SIGN 0x02
+#endif
+
+#ifndef DTOSTR_UPPERCASE
+#define	DTOSTR_UPPERCASE 0x04
+#endif
+
 #define SCPI_doubleToStr(v, s, l) strlen(dtostre((v), (s), 6, DTOSTR_PLUS_SIGN | DTOSTRE_ALWAYS_SIGN | DTOSTR_UPPERCASE))
 #else
 #define SCPI_doubleToStr(v, s, l) snprintf((s), (l), "%lg", (v))


### PR DESCRIPTION
I suggest explicitly declaring `dtostre` function and `DTOSTR_xxx` constants. I could not find definition of these constants in my `avr-lib`, so in order to build the code I had to define them myself.