### PR TITLE
Adaption to be able to insert device specific error codes

### DIFF
--- a/libscpi/inc/scpi/config.h
+++ b/libscpi/inc/scpi/config.h
@@ -37,7 +37,7 @@
 #ifndef __SCPI_CONFIG_H_
 #define __SCPI_CONFIG_H_
 
-#ifdef	__cplusplus
+#ifdef   __cplusplus
 extern "C" {
 #endif
 
@@ -46,7 +46,7 @@ extern "C" {
 #define ENDCODE_LF              2      /*   use a <LF> line feed aka       '\n' as termination charcter */
 #define ENDCODE_CRLF            3      /*   use <CR><LF> carriage return + line feed aka "\r\n" as termination charcters */
    
-#define USED_ENDCODE            ENDCODE_LF
+#define USED_ENDCODE            ENDCODE_CRLF
    
 /* select the error list(s) */
 #define ERR_SCPI_MINIMUM        1
@@ -54,7 +54,7 @@ extern "C" {
 #define ERR_SCPI_MIN_PLUS_USER  3
 #define ERR_SCPI_FULL_PLUS_USER 4
 
-#define USED_SCPI_ERROR_LIST    ERR_SCPI_MIN_PLUS_USER
+#define USED_SCPI_ERROR_LIST    ERR_SCPI_MINIMUM
    
 /* Compiler specific */
 /* ARM, e.g. Cortex-M CPUs */
@@ -68,7 +68,7 @@ extern "C" {
 #if defined(_CVI_)
 #define HAVE_STRNLEN            0
 #define HAVE_STRNCASECMP        0
-#define HAVE_STRNICMP           0
+#define HAVE_STRNICMP           1
 #endif
 
 /* 8bit PIC - PIC16, etc */
@@ -113,9 +113,9 @@ extern "C" {
 
 /* define local macros depending on existance of strnlen */
 #if HAVE_STRNLEN
-#define SCPIDEFINE_strnlen(s, l)	strnlen((s), (l))
+#define SCPIDEFINE_strnlen(s, l) strnlen((s), (l))
 #else
-#define SCPIDEFINE_strnlen(s, l)	BSD_strnlen((s), (l))
+#define SCPIDEFINE_strnlen(s, l) BSD_strnlen((s), (l))
 #endif
 
 /* define local macros depending on existance of strncasecmp and strnicmp */
@@ -134,7 +134,7 @@ extern "C" {
 #endif
 
 
-#ifdef	__cplusplus
+#ifdef   __cplusplus
 }
 #endif
 

--- a/libscpi/inc/scpi/config.h
+++ b/libscpi/inc/scpi/config.h
@@ -58,7 +58,7 @@ extern "C" {
    
 /* Compiler specific */
 /* ARM, e.g. Cortex-M CPUs */
-#if defined(__arm__)
+#if defined(__CC_ARM)
 #define HAVE_STRNLEN            0
 #define HAVE_STRNCASECMP        1
 #define HAVE_STRNICMP           0

--- a/libscpi/inc/scpi/config.h
+++ b/libscpi/inc/scpi/config.h
@@ -41,7 +41,36 @@
 extern "C" {
 #endif
 
+/* set the termination character(s)   */
+#define ENDCODE_CR              1      /*   use a <CR> carriage return aka '\r' as termination charcter */
+#define ENDCODE_LF              2      /*   use a <LF> line feed aka       '\n' as termination charcter */
+#define ENDCODE_CRLF            3      /*   use <CR><LF> carriage return + line feed aka "\r\n" as termination charcters */
+   
+#define USED_ENDCODE            ENDCODE_LF
+   
+/* select the error list(s) */
+#define ERR_SCPI_MINIMUM        1
+#define ERR_SCPI_FULL           2
+#define ERR_SCPI_MIN_PLUS_USER  3
+#define ERR_SCPI_FULL_PLUS_USER 4
+
+#define USED_SCPI_ERROR_LIST    ERR_SCPI_MIN_PLUS_USER
+   
 /* Compiler specific */
+/* ARM, e.g. Cortex-M CPUs */
+#if defined(__arm__)
+#define HAVE_STRNLEN            0
+#define HAVE_STRNCASECMP        1
+#define HAVE_STRNICMP           0
+#endif
+
+/* National Instruments (R) CVI x86/x64 PC platform */
+#if defined(_CVI_)
+#define HAVE_STRNLEN            0
+#define HAVE_STRNCASECMP        0
+#define HAVE_STRNICMP           0
+#endif
+
 /* 8bit PIC - PIC16, etc */
 #if defined(_MPC_)
 #define HAVE_STRNLEN            0

--- a/libscpi/inc/scpi/error.h
+++ b/libscpi/inc/scpi/error.h
@@ -35,11 +35,12 @@
  */
 
 #ifndef SCPI_ERROR_H
-#define	SCPI_ERROR_H
+#define  SCPI_ERROR_H
 
 #include "scpi/types.h"
+#include "scpi/config.h"
 
-#ifdef	__cplusplus
+#ifdef   __cplusplus
 extern "C" {
 #endif
 
@@ -50,23 +51,154 @@ extern "C" {
     int32_t SCPI_ErrorCount(scpi_t * context);
     const char * SCPI_ErrorTranslate(int16_t err);
 
-/* http://en.wikipedia.org/wiki/X_Macro */
-#define LIST_OF_ERRORS \
-    X(SCPI_ERROR_INVALID_CHARACTER,    -101, "Invalid character")              \
-    X(SCPI_ERROR_SYNTAX,               -102, "Syntax error")                   \
-    X(SCPI_ERROR_INVALID_SEPARATOR,    -103, "Invalid separator")              \
-    X(SCPI_ERROR_DATA_TYPE_ERROR,      -104, "Data type error")                \
-    X(SCPI_ERROR_PARAMETER_NOT_ALLOWED,-108, "Parameter not allowed")          \
-    X(SCPI_ERROR_MISSING_PARAMETER,    -109, "Missing parameter")              \
-    X(SCPI_ERROR_UNDEFINED_HEADER,     -113, "Undefined header")               \
-    X(SCPI_ERROR_INVALID_SUFFIX,       -131, "Invalid suffix")                 \
-    X(SCPI_ERROR_SUFFIX_NOT_ALLOWED,   -138, "Suffix not allowed")             \
-    X(SCPI_ERROR_INVALID_STRING_DATA,  -151, "Invalid string data")            \
-    X(SCPI_ERROR_INVALID_BLOCK_DATA,   -161, "Invalid block data")             \
-    X(SCPI_ERROR_EXECUTION_ERROR,      -200, "Execution error")                \
-    X(SCPI_ERROR_ILLEGAL_PARAMETER_VALUE,-224,"Illegal parameter value")       \
-    X(SCPI_ERROR_SYSTEM_ERROR,         -310, "System error")                   \
 
+/* http://en.wikipedia.org/wiki/X_Macro */
+#if ((USED_SCPI_ERROR_LIST == ERR_SCPI_MINIMUM) || (USED_SCPI_ERROR_LIST == ERR_SCPI_MIN_PLUS_USER))
+
+#define LIST_OF_ERRORS \
+    X(SCPI_ERROR_INVALID_CHARACTER,          -101, "Invalid character")                            \
+    X(SCPI_ERROR_SYNTAX,                     -102, "Syntax error")                                 \
+    X(SCPI_ERROR_INVALID_SEPARATOR,          -103, "Invalid separator")                            \
+    X(SCPI_ERROR_DATA_TYPE_ERROR,            -104, "Data type error")                              \
+    X(SCPI_ERROR_PARAMETER_NOT_ALLOWED,      -108, "Parameter not allowed")                        \
+    X(SCPI_ERROR_MISSING_PARAMETER,          -109, "Missing parameter")                            \
+    X(SCPI_ERROR_UNDEFINED_HEADER,           -113, "Undefined header")                             \
+    X(SCPI_ERROR_INVALID_SUFFIX,             -131, "Invalid suffix")                               \
+    X(SCPI_ERROR_SUFFIX_NOT_ALLOWED,         -138, "Suffix not allowed")                           \
+    X(SCPI_ERROR_INVALID_STRING_DATA,        -151, "Invalid string data")                          \
+    X(SCPI_ERROR_INVALID_BLOCK_DATA,         -161, "Invalid block data")                           \
+    X(SCPI_ERROR_EXECUTION_ERROR,            -200, "Execution error")                              \
+    X(SCPI_ERROR_ILLEGAL_PARAMETER_VALUE,    -224,"Illegal parameter value")                       \
+    X(SCPI_ERROR_SYSTEM_ERROR,               -310, "System error")                                 \
+
+
+#elif ((USED_SCPI_ERROR_LIST == ERR_SCPI_FULL) || (USED_SCPI_ERROR_LIST == ERR_SCPI_FULL_PLUS_USER))
+
+#define LIST_OF_ERRORS \
+    X(SCPI_ERROR_COMMAND,                    -100, "Command error")                                \
+    X(SCPI_ERROR_INVALID_CHARACTER,          -101, "Invalid character")                            \
+    X(SCPI_ERROR_SYNTAX,                     -102, "Syntax error")                                 \
+    X(SCPI_ERROR_INVALID_SEPARATOR,          -103, "Invalid separator")                            \
+    X(SCPI_ERROR_DATA_TYPE_ERROR,            -104, "Data type error")                              \
+    X(SCPI_ERROR_GET_NOT_ALLOWED,            -105, "GET not allowed")                              \
+    X(SCPI_ERROR_PARAMETER_NOT_ALLOWED,      -108, "Parameter not allowed")                        \
+    X(SCPI_ERROR_MISSING_PARAMETER,          -109, "Missing parameter")                            \
+    X(SCPI_ERROR_COMMAND_HEADER,             -110, "Command header error")                         \
+    X(SCPI_ERROR_HEADER_SEPARATOR,           -111, "Header separator error")                       \
+    X(SCPI_ERROR_PRG_MNEMONIC_TOO_LONG,      -112, "Program mnemonic too long")                    \
+    X(SCPI_ERROR_UNDEFINED_HEADER,           -113, "Undefined header")                             \
+    X(SCPI_ERROR_HEADER_SUFFIX_OUTOFRANGE,   -114, "Header suffix out of range")                   \
+    X(SCPI_ERROR_UNEXP_NUM_OF_PARAMETER,     -115, "Unexpected number of parameters")              \
+    X(SCPI_ERROR_NUMERIC_DATA_ERROR,         -120, "Numeric data error")                           \
+    X(SCPI_ERROR_INVAL_CHAR_IN_NUMBER,       -121, "Invalid character in number")                  \
+    X(SCPI_ERROR_EXPONENT_TOO_LONG,          -123, "Exponent too large")                           \
+    X(SCPI_ERROR_TOO_MANY_DIGITS,            -124, "Too many digits")                              \
+    X(SCPI_ERROR_NUMERIC_DATA_NOT_ALLOWED,   -128, "Numeric data not allowed")                     \
+    X(SCPI_ERROR_SUFFIX_ERROR,               -130, "Suffix error")                                 \
+    X(SCPI_ERROR_INVALID_SUFFIX,             -131, "Invalid suffix")                               \
+    X(SCPI_ERROR_SUFFIX_TOO_LONG,            -134, "Suffix too long")                              \
+    X(SCPI_ERROR_SUFFIX_NOT_ALLOWED,         -138, "Suffix not allowed")                           \
+    X(SCPI_ERROR_CHARACTER_DATA_ERROR,       -140, "Character data error")                         \
+    X(SCPI_ERROR_INVAL_CHARACTER_DATA,       -141, "Invalid character data")                       \
+    X(SCPI_ERROR_CHARACTER_DATA_TOO_LONG,    -144, "Character data too long")                      \
+    X(SCPI_ERROR_CHARACTER_DATA_NOT_ALLOWED, -148, "Character data not allowed")                   \
+    X(SCPI_ERROR_STRING_DATA_ERROR,          -150, "String data error")                            \
+    X(SCPI_ERROR_INVALID_STRING_DATA,        -151, "Invalid string data")                          \
+    X(SCPI_ERROR_STRING_DATA_NOT_ALLOWED,    -158, "String data not allowed")                      \
+    X(SCPI_ERROR_BLOCK_DATA_ERROR,           -160, "Block data error")                             \
+    X(SCPI_ERROR_INVALID_BLOCK_DATA,         -161, "Invalid block data")                           \
+    X(SCPI_ERROR_BLOCK_DATA_NOT_ALLOWED,     -168, "Block data not allowed")                       \
+    X(SCPI_ERROR_EXPRESSION_PARSING_ERROR,    -170, "Expression error")                             \
+    X(SCPI_ERROR_INVAL_EXPRESSION,           -171, "Invalid expression")                           \
+    X(SCPI_ERROR_EXPRESSION_DATA_NOT_ALLOWED,-178, "Expression data not allowed")                  \
+    X(SCPI_ERROR_MACRO_DEFINITION_ERROR,     -180, "Macro error")                                  \
+    X(SCPI_ERROR_INVAL_OUTSIDE_MACRO_DEF,    -181, "Invalid outside macro definition")             \
+    X(SCPI_ERROR_INVAL_INSIDE_MACRO_DEF,     -183, "Invalid inside macro definition")              \
+    X(SCPI_ERROR_MACRO_PARAMETER_ERROR,      -184, "Macro parameter error")                        \
+    X(SCPI_ERROR_EXECUTION_ERROR,            -200, "Execution error")                              \
+    X(SCPI_ERROR_INVAL_WHILE_IN_LOCAL,       -201, "Invalid while in local")                       \
+    X(SCPI_ERROR_SETTINGS_LOST_DUE_TO_RTL,   -202, "Settings lost due to rtl")                     \
+    X(SCPI_ERROR_COMMAND_PROTECTED,          -203, "Command protected TK024")                      \
+    X(SCPI_ERROR_TRIGGER_ERROR,              -210, "Trigger error")                                \
+    X(SCPI_ERROR_TRIGGER_IGNORED,            -211, "Trigger ignored")                              \
+    X(SCPI_ERROR_ARM_IGNORED,                -212, "Arm ignored")                                  \
+    X(SCPI_ERROR_INIT_IGNORED,               -213, "Init ignored")                                 \
+    X(SCPI_ERROR_TRIGGER_DEADLOCK,           -214, "Trigger deadlock")                             \
+    X(SCPI_ERROR_ARM_DEADLOCK,               -215, "Arm deadlock")                                 \
+    X(SCPI_ERROR_PARAMETER_ERROR,            -220, "Parameter error")                              \
+    X(SCPI_ERROR_SETTINGS_CONFLICT,          -221, "Settings conflict")                            \
+    X(SCPI_ERROR_DATA_OUT_OF_RANGE,          -222, "Data out of range")                            \
+    X(SCPI_ERROR_TOO_MUCH_DATA,              -223, "Too much data")                                \
+    X(SCPI_ERROR_ILLEGAL_PARAMETER_VALUE,    -224, "Illegal parameter value")                      \
+    X(SCPI_ERROR_OUT_OF_MEMORY_FOR_REQ_OP,   -225, "Out of memory")                                \
+    X(SCPI_ERROR_LISTS_NOT_SAME_LENGTH,      -226, "Lists not same length")                        \
+    X(SCPI_ERROR_DATA_CORRUPT,               -230, "Data corrupt or stale")                        \
+    X(SCPI_ERROR_DATA_QUESTIONABLE,          -231, "Data questionable")                            \
+    X(SCPI_ERROR_INVAL_VERSION,              -233, "Invalid version")                              \
+    X(SCPI_ERROR_HARDWARE_ERROR,             -240, "Hardware error")                               \
+    X(SCPI_ERROR_HARDWARE_MISSING,           -241, "Hardware missing")                             \
+    X(SCPI_ERROR_MASS_STORAGE_ERROR,         -250, "Mass storage error")                           \
+    X(SCPI_ERROR_MISSING_MASS_STORAGE,       -251, "Missing mass storage")                         \
+    X(SCPI_ERROR_MISSING_MASS_MEDIA,         -252, "Missing media")                                \
+    X(SCPI_ERROR_CORRUPT_MEDIA,              -253, "Corrupt media")                                \
+    X(SCPI_ERROR_MEDIA_FULL,                 -254, "Media full")                                   \
+    X(SCPI_ERROR_DIRECTORY_FULL,             -255, "Directory full")                               \
+    X(SCPI_ERROR_FILE_NAME_NOT_FOUND,        -256, "File name not found")                          \
+    X(SCPI_ERROR_FILE_NAME_ERROR,            -257, "File name error")                              \
+    X(SCPI_ERROR_MEDIA_PROTECTED,            -258, "Media protected")                              \
+    X(SCPI_ERROR_EXPRESSION_EXECUTING_ERROR, -260, "Expression error")                             \
+    X(SCPI_ERROR_MATH_ERROR_IN_EXPRESSION,   -261, "Math error in expression")                     \
+    X(SCPI_ERROR_MACRO_UNDEF_EXEC_ERROR,     -270, "Macro error")                                  \
+    X(SCPI_ERROR_MACRO_SYNTAX_ERROR,         -271, "Macro syntax error")                           \
+    X(SCPI_ERROR_MACRO_EXECUTION_ERROR,      -272, "Macro execution error")                        \
+    X(SCPI_ERROR_ILLEGAL_MACRO_LABEL,        -273, "Illegal macro label")                          \
+    X(SCPI_ERROR_IMPROPER_USED_MACRO_PARAM,  -274, "Macro parameter error")                        \
+    X(SCPI_ERROR_MACRO_DEFINITION_TOO_LONG,  -275, "Macro definition too long")                    \
+    X(SCPI_ERROR_MACRO_RECURSION_ERROR,      -276, "Macro recursion error")                        \
+    X(SCPI_ERROR_MACRO_REDEF_NOT_ALLOWED,    -277, "Macro redefinition not allowed")               \
+    X(SCPI_ERROR_MACRO_HEADER_NOT_FOUND,     -278, "Macro header not found")                       \
+    X(SCPI_ERROR_PROGRAM_ERROR,              -280, "Program error")                                \
+    X(SCPI_ERROR_CANNOT_CREATE_PROGRAM,      -281, "Cannot create program")                        \
+    X(SCPI_ERROR_ILLEGAL_PROGRAM_NAME,       -282, "Illegal program name")                         \
+    X(SCPI_ERROR_ILLEGAL_VARIABLE_NAME,      -283, "Illegal variable name")                        \
+    X(SCPI_ERROR_PROGRAM_CURRENTLY_RUNNING,  -284, "Program currently running")                    \
+    X(SCPI_ERROR_PROGRAM_SYNTAX_ERROR,       -285, "Program syntax error")                         \
+    X(SCPI_ERROR_PROGRAM_RUNTIME_ERROR,      -286, "Program runtime error")                        \
+    X(SCPI_ERROR_MEMORY_USE_ERROR,           -290, "Memory use error")                             \
+    X(SCPI_ERROR_OUT_OF_MEMORY,              -291, "Out of memory")                                \
+    X(SCPI_ERROR_REF_NAME_DOES_NOT_EXIST,    -292, "Referenced name does not exist")               \
+    X(SCPI_ERROR_REF_NAME_ALREADY_EXISTS,    -293, "Referenced name already exists")               \
+    X(SCPI_ERROR_INCOMPATIBLE_TYPE,          -294, "Incompatible type")                            \
+    X(SCPI_ERROR_DEVICE_ERROR,               -300, "Device specific error")                        \
+    X(SCPI_ERROR_SYSTEM_ERROR,               -310, "System error")                                 \
+    X(SCPI_ERROR_MEMORY_ERROR,               -311, "Memory error")                                 \
+    X(SCPI_ERROR_PUD_MEMORY_LOST,            -312, "PUD memory lost")                              \
+    X(SCPI_ERROR_CALIBRATION_MEMORY_LOST,    -313, "Calibration memory lost")                      \
+    X(SCPI_ERROR_SAVE_RECALL_MEMORY_LOST,    -314, "Save/recall memory lost")                      \
+    X(SCPI_ERROR_CONFIGURATION_MEMORY_LOST,  -315, "Configuration memory lost")                    \
+    X(SCPI_ERROR_STORAGE_FAULT,              -320, "Storage fault")                                \
+    X(SCPI_ERROR_OUT_OF_DEVICE_MEMORY,       -321, "Out of memory")                                \
+    X(SCPI_ERROR_SELF_TEST_FAILED,           -330, "Self-test failed")                             \
+    X(SCPI_ERROR_CALIBRATION_FAILED,         -340, "Calibration failed")                           \
+    X(SCPI_ERROR_QUEUE_OVERFLOW,             -350, "Queue overflow")                               \
+    X(SCPI_ERROR_COMMUNICATION_ERROR,        -360, "Communication error")                          \
+    X(SCPI_ERROR_PARITY_ERROR_IN_CMD_MSG,    -361, "Parity error in program message")              \
+    X(SCPI_ERROR_FRAMING_ERROR_IN_CMD_MSG,   -362, "Framing error in program message")             \
+    X(SCPI_ERROR_INPUT_BUFFER_OVERRUN,       -363, "Input buffer overrun")                         \
+    X(SCPI_ERROR_TIME_OUT,                   -365, "Time out error")                               \
+    X(SCPI_ERROR_QUERY_ERROR,                -400, "Query error")                                  \
+    X(SCPI_ERROR_QUERY_INTERRUPTED,          -410, "Query INTERRUPTED")                            \
+    X(SCPI_ERROR_QUERY_UNTERMINATED,         -420, "Query UNTERMINATED")                           \
+    X(SCPI_ERROR_QUERY_DEADLOCKED,           -430, "Query DEADLOCKED")                             \
+    X(SCPI_ERROR_QUERY_UNTERM_INDEF_RESP,    -440, "Query UNTERMINATED after indefinite response") \
+    X(SCPI_ERROR_POWER_ON,                   -500, "Power on")                                     \
+    X(SCPI_ERROR_USER_REQUEST,               -600, "User request")                                 \
+    X(SCPI_ERROR_REQUEST_CONTROL,            -700, "Request control")                              \
+    X(SCPI_ERROR_OPERATION_COMPLETE,         -800, "Operation complete")                           \
+
+#else
+#error no SCPI error list defined!
+#endif
 
 enum {
 #define X(def, val, str) def = val,
@@ -74,9 +206,9 @@ LIST_OF_ERRORS
 #undef X
 };
 
-#ifdef	__cplusplus
+#ifdef   __cplusplus
 }
 #endif
 
-#endif	/* SCPI_ERROR_H */
+#endif   /* SCPI_ERROR_H */
 

--- a/libscpi/inc/scpi/parser.h
+++ b/libscpi/inc/scpi/parser.h
@@ -39,7 +39,7 @@
 
 #include <string.h>
 #include "scpi/types.h"
-#include "scpi/debug.h"
+#include "scpi/scpi_debug.h"
 
 #ifdef	__cplusplus
 extern "C" {

--- a/libscpi/inc/scpi/scpi_debug.h
+++ b/libscpi/inc/scpi/scpi_debug.h
@@ -1,0 +1,57 @@
+/*-
+ * Copyright (c) 2012-2013 Jan Breuer,
+ *
+ * All Rights Reserved
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file   scpi_debug.h
+ * @date   Thu Nov 15 10:58:45 UTC 2012
+ * 
+ * @brief  SCPI debug function
+ * 
+ * 
+ */
+
+#ifndef SCPI_DEBUG_H
+#define	SCPI_DEBUG_H
+
+#include "scpi/types.h"
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+
+#define SCPI_DEBUG_COMMAND(a)   SCPI_DebugCommand(a)
+	
+scpi_bool_t SCPI_DebugCommand(scpi_t * context);
+
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* SCPI_DEBUG_H */
+

--- a/libscpi/inc/scpi/types.h
+++ b/libscpi/inc/scpi/types.h
@@ -41,7 +41,12 @@
 
 #include <stddef.h>
 #include <stdint.h>
+
+#if defined(_CVI_)
+   typedef unsigned char bool;
+#else
 #include <stdbool.h>
+#endif
 
 #ifdef  __cplusplus
 extern "C" {

--- a/libscpi/src/lexer.c
+++ b/libscpi/src/lexer.c
@@ -594,8 +594,8 @@ static int skipBinNum(lex_state_t * state) {
  * @return 
  */
 int scpiLex_NondecimalNumericData(lex_state_t * state, scpi_token_t * token) {
-    token->ptr = state->pos;
     int someNumbers = 0;
+    token->ptr = state->pos;
     if (skipChr(state, '#')) {
         if (!iseos(state)) {
             if (isH(state->pos[0])) {
@@ -630,7 +630,7 @@ static int isascii7bit(int c) {
     return (c >= 0) && (c <= 0x7f);
 }
 
-static int skipQuoteProgramData(lex_state_t * state, int quote) {
+static void skipQuoteProgramData(lex_state_t * state, int quote) {
     while (!iseos(state)) {
         if (isascii7bit(state->pos[0]) && !ischr(state, quote)) {
             state->pos++;
@@ -646,11 +646,11 @@ static int skipQuoteProgramData(lex_state_t * state, int quote) {
     }
 }
 
-static int skipDoubleQuoteProgramData(lex_state_t * state) {
+static void skipDoubleQuoteProgramData(lex_state_t * state) {
     skipQuoteProgramData(state, '"');
 }
 
-static int skipSingleQuoteProgramData(lex_state_t * state) {
+static void skipSingleQuoteProgramData(lex_state_t * state) {
     skipQuoteProgramData(state, '\'');
 }
 
@@ -716,8 +716,8 @@ int scpiLex_ArbitraryBlockProgramData(lex_state_t * state, scpi_token_t * token)
     int i;
     int arbitraryBlockLength = 0;
     const char * ptr = state->pos;
-    token->ptr = state->pos;
     int validData = -1;
+    token->ptr = state->pos;
 
     if (skipChr(state, '#')) {
         if (!iseos(state) && isNonzeroDigit(state->pos[0])) {

--- a/libscpi/src/parser.c
+++ b/libscpi/src/parser.c
@@ -44,6 +44,7 @@
 #include "scpi/error.h"
 #include "scpi/constants.h"
 #include "scpi/utils.h"
+#include "scpi/scpi_debug.h"
 
 /**
  * Write data to SCPI output
@@ -90,7 +91,15 @@ static size_t writeDelimiter(scpi_t * context) {
 static size_t writeNewLine(scpi_t * context) {
     if (context->output_count > 0) {
         size_t len;
+#if   (USED_ENDCODE == ENDCODE_CR)
+         len = writeData(context, "\r", 1);
+#elif (USED_ENDCODE == ENDCODE_LF)
+         len = writeData(context, "\n", 1);
+#elif (USED_ENDCODE == ENDCODE_CRLF)
         len = writeData(context, "\r\n", 2);
+#else
+#error no termination character defined
+#endif
         flushData(context);
         return len;
     } else {
@@ -528,7 +537,7 @@ scpi_bool_t SCPI_ParamIsNumber(scpi_parameter_t * parameter, scpi_bool_t suffixA
  * @param context
  * @param parameter
  * @param value result
- * @return true if succesful
+ * @return TRUE if succesful
  */
 scpi_bool_t SCPI_ParamToInt(scpi_t * context, scpi_parameter_t * parameter, int32_t * value) {
 
@@ -556,7 +565,7 @@ scpi_bool_t SCPI_ParamToInt(scpi_t * context, scpi_parameter_t * parameter, int3
  * @param context
  * @param parameter
  * @param value result
- * @return true if succesful
+ * @return TRUE if succesful
  */
 scpi_bool_t SCPI_ParamToDouble(scpi_t * context, scpi_parameter_t * parameter, double * value) {
     scpi_bool_t result = FALSE;
@@ -783,7 +792,7 @@ scpi_bool_t SCPI_ParamToChoice(scpi_t * context, scpi_parameter_t * parameter, c
  * @param options specifications of choices numbers (patterns)
  * @param tag numerical representatio of choice
  * @param text result text
- * @return true if succesfule, else false
+ * @return TRUE if succesfule, else false
  */
 scpi_bool_t SCPI_ChoiceToName(const scpi_choice_def_t * options, int32_t tag, const char ** text) {
     int i;
@@ -1012,11 +1021,13 @@ int scpiParser_detectProgramMessageUnit(scpi_parser_state_t * state, char * buff
  * @return 
  */
 scpi_bool_t SCPI_IsCmd(scpi_t * context, const char * cmd) {
+    const char * pattern;
+
     if (!context->param_list.cmd) {
         return FALSE;
     }
 
-    const char * pattern = context->param_list.cmd->pattern;
+    pattern = context->param_list.cmd->pattern;
     return matchCommand (pattern, cmd, strlen (cmd), NULL, 0);
 }
 

--- a/libscpi/src/scpi_debug.c
+++ b/libscpi/src/scpi_debug.c
@@ -1,0 +1,62 @@
+/*-
+ * Copyright (c) 2012-2013 Jan Breuer,
+ *
+ * All Rights Reserved
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file   scpi_debug.c
+ * @date   Thu Nov 15 10:58:45 UTC 2012
+ * 
+ * @brief  Debugging SCPI
+ * 
+ * 
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include "debug.h"            /* this includes platform specific printing capabilities */
+#include "scpi/scpi_debug.h"
+
+/**
+ * Debug function: show current command and its parameters
+ * @param context
+ * @return 
+ */
+scpi_bool_t SCPI_DebugCommand(scpi_t * context)
+{
+/*	size_t res;
+	printf("**DEBUG: %s (\"", context->param_list.cmd->pattern);
+	res =	fwrite(context->param_list.lex_state.buffer, 1, context->param_list.lex_state.len, stdout);
+	(void)res;
+        printf("\" - %lu\r\n", (unsigned long)context->param_list.lex_state.len);
+*/
+
+   /* The PRINT_DEBUG and PRINT_BUFFER macros are defined in debug.h and are platform specific */
+	PRINT_DEBUG("SCPI: %s (\"", context->param_list.cmd->pattern);
+	PRINT_BUFFER((uint8_t *)context->param_list.lex_state.buffer, context->param_list.lex_state.len);
+	PRINT_DEBUG("\" - %lu\r\n", (unsigned long)context->param_list.lex_state.len);
+	
+	return TRUE;
+}

--- a/libscpi/src/utils.c
+++ b/libscpi/src/utils.c
@@ -254,7 +254,7 @@ size_t skipWhitespace(const char * cmd, size_t len) {
  * @param len - max search length
  * @return position of separator or len
  */
-size_t patternSeparatorShortPos(const char * pattern, size_t len) {
+static size_t patternSeparatorShortPos(const char * pattern, size_t len) {
     size_t i;
     for (i = 0; (i < len) && pattern[i]; i++) {
         if (islower((unsigned char) pattern[i])) {
@@ -270,7 +270,7 @@ size_t patternSeparatorShortPos(const char * pattern, size_t len) {
  * @param len - max search length
  * @return position of separator or len
  */
-size_t patternSeparatorPos(const char * pattern, size_t len) {
+static size_t patternSeparatorPos(const char * pattern, size_t len) {
 
     char * separator = strnpbrk(pattern, len, "?:[]");
     if (separator == NULL) {
@@ -286,7 +286,7 @@ size_t patternSeparatorPos(const char * pattern, size_t len) {
  * @param len - max search length
  * @return position of separator or len
  */
-size_t cmdSeparatorPos(const char * cmd, size_t len) {
+static size_t cmdSeparatorPos(const char * cmd, size_t len) {
     char * separator = strnpbrk(cmd, len, ":?");
     size_t result;
     if (separator == NULL) {

--- a/libscpi/src/utils.c
+++ b/libscpi/src/utils.c
@@ -338,7 +338,7 @@ scpi_bool_t matchCommand(const char * pattern, const char * cmd, size_t len, int
     int rightFlag = 0; // flag for ']' on right
     int cmd_sep_pos = 0;
 
-    size_t numbers_idx = -1;
+    int32_t numbers_idx = -1;         /* Lutz Hoerl, Thorlabs: changed type from size_t to int, size_t is positive only, int does not produce unsigne warnings */
     int32_t *number_ptr = NULL;
 
     const char * pattern_ptr = pattern;
@@ -548,7 +548,7 @@ int OUR_strncasecmp(const char *s1, const char *s2, size_t n) {
         if (c1 != c2) {
             return c1 - c2;
         }
-        if (c1 = '\0') {
+        if (c1 == '\0') {        /* Lutz Hoerl, Thorlabs: think this (c1 = '\0') was really a bug */
             return 0;
         }
     }


### PR DESCRIPTION
added full SCPI error messages
added list for device dependent error messages
some minor changes to get rid of compiler warnings
added support for Keil ARM compiler
added support for National Instruments CVI compiler
removed bug if(c = '\0')...