### PR TITLE
TEST_Text: Fix segmentation fault for empty text string

### DIFF
--- a/examples/common/scpi-def.c
+++ b/examples/common/scpi-def.c
@@ -170,7 +170,10 @@ static scpi_result_t TEST_Text(scpi_t * context) {
     char buffer[100];
     size_t copy_len;
 
-    SCPI_ParamCopyText(context, buffer, sizeof(buffer), &copy_len, FALSE);
+    if (!SCPI_ParamCopyText(context, buffer, sizeof(buffer), &copy_len, TRUE)) {
+	return SCPI_RES_ERR;
+    }
+    
     buffer[copy_len] = '\0';
 
     fprintf(stderr, "TEXT: ***%s***\r\n", buffer);


### PR DESCRIPTION
SCPI Command ```TEST:TEXT``` from scpi-def.c segfaults if parameter for test:text is an empty string ("" or just nothing).

This should fix it.