### PR TITLE
Newtypes

### DIFF
--- a/libscpi/src/utils.c
+++ b/libscpi/src/utils.c
@@ -141,7 +141,7 @@ size_t UInt32ToStrBaseSign(uint32_t val, char * str, size_t len, int8_t base, sc
  * @return number of bytes written to str (without '\0')
  */
 size_t SCPI_Int32ToStr(int32_t val, char * str, size_t len) {
-    return UInt32ToStrBaseSign((int32_t) val, str, len, 10, TRUE);
+    return UInt32ToStrBaseSign((uint32_t) val, str, len, 10, TRUE);
 }
 
 /**
@@ -229,7 +229,7 @@ size_t UInt64ToStrBaseSign(uint64_t val, char * str, size_t len, int8_t base, sc
  * @return number of bytes written to str (without '\0')
  */
 size_t SCPI_Int64ToStr(int64_t val, char * str, size_t len) {
-    return UInt64ToStrBaseSign((int64_t) val, str, len, 10, TRUE);
+    return UInt64ToStrBaseSign((uint64_t) val, str, len, 10, TRUE);
 }
 
 /**

--- a/libscpi/test/test_scpi_utils.c
+++ b/libscpi/test/test_scpi_utils.c
@@ -85,6 +85,16 @@ static void test_Int32ToStr() {
         CU_ASSERT(len == strlen(ref));
         CU_ASSERT_STRING_EQUAL(str, ref);
     }
+
+    int16_t val16[] = {0, 1, -1, INT16_MIN, INT16_MAX, 0x0123, 0x4567, 0x89ab, 0xcdef};
+    int N16 = sizeof (val16) / sizeof (int16_t);
+    // test signed conversion to decimal numbers
+    for (i = 0; i < N16; i++) {
+        len = SCPI_Int32ToStr((int32_t) val16[i], str, max);
+        snprintf(ref, max, "%"PRIi16, val16[i]);
+        CU_ASSERT(len == strlen(ref));
+        CU_ASSERT_STRING_EQUAL(str, ref);
+    }
 }
 
 static void test_UInt32ToStrBase() {


### PR DESCRIPTION
In the first commit I have fixed a couple of wrong casts in my code. You can cherry pick only this one.

The second commit, which you can skip, is for a casting issue I have with my code, it might be an issue in the cross compilation toolchain, since I was not able to reproduce it with scpi-parser unit tests on native ARM or x86 platforms.

But there is a different failure while running tests on ARM, which is not present on x86. The report is provided below.
```
     CUnit - A unit testing framework for C - Version 2.1-2
     http://cunit.sourceforge.net/

Suite: Parser
  Test: SCPI_ParamInt32 ...passed
  Test: SCPI_ParamUInt32 ...passed
  Test: SCPI_ParamInt64 ...FAILED
    1. test/test_parser.c:429  - CU_ASSERT_EQUAL(value,9223372036854775807LL)
    2. test/test_parser.c:430  - CU_ASSERT_EQUAL(value,-9223372036854775807LL)
  Test: SCPI_ParamUInt64 ...passed
  Test: SCPI_ParamFloat ...passed
  Test: SCPI_ParamDouble ...passed
  Test: SCPI_ParamCharacters ...passed
  Test: SCPI_ParamCopyText ...passed
  Test: Commands handling ...passed
  Test: Error handling ...passed
  Test: IEEE 488.2 Mandatory commands ...passed
  Test: Numeric list ...passed
  Test: Channel list ...passed

Run Summary:    Type  Total    Ran Passed Failed Inactive
              suites      1      1    n/a      0        0
               tests     13     13     12      1        0
             asserts    432    432    430      2      n/a
```