### PR TITLE
Fix uninitialised variable in RESULT_ARRAY macro.

### DIFF
--- a/libscpi/src/parser.c
+++ b/libscpi/src/parser.c
@@ -1492,7 +1492,7 @@ static size_t parserResultArrayBinary(scpi_t * context, const void * array, size
 
 
 #define RESULT_ARRAY(func) do {\
-    size_t result;\
+    size_t result = 0;\
     if (format == SCPI_FORMAT_ASCII) {\
         size_t i;\
         for (i = 0; i < count; i++) {\


### PR DESCRIPTION
gcc complains: 'result' may be used uninitialized in this function
[-Wmaybe-uninitialized]