### PR TITLE
Minor bugfixes for avr-gcc compiler detection and for USE_COMMAND_TAGS

### DIFF
--- a/libscpi/inc/scpi/cc.h
+++ b/libscpi/inc/scpi/cc.h
@@ -116,6 +116,8 @@ extern "C" {
 #if defined(__AVR__)
 #include <stdlib.h>
 #define HAVE_DTOSTRE            1
+#undef HAVE_STRTOF
+#define HAVE_STRTOF				0
 #endif
 
 /* default values */

--- a/libscpi/inc/scpi/types.h
+++ b/libscpi/inc/scpi/types.h
@@ -113,7 +113,12 @@ extern "C" {
 
     typedef struct _scpi_command_t scpi_command_t;
 
-#define SCPI_CMD_LIST_END       {NULL, NULL, 0}
+#if USE_COMMAND_TAGS
+	#define SCPI_CMD_LIST_END       {NULL, NULL, 0}
+#else
+	#define SCPI_CMD_LIST_END       {NULL, NULL}
+#endif
+
 
     /* scpi interface */
     typedef struct _scpi_t scpi_t;


### PR DESCRIPTION
This pull request contains two small fixes I have been using on my local branch.  Although they are simple, they haven't been tested much, or indeed on any other platform than an AVR.  I probably won't do much more testing, so I leave it to you to decide whether that is up to the standard to merge.

The first fix is in compiler detection. When using `avr-gcc` with `-std=gnu99` (which is the default in Atmel Studio) the compiler detects as C99, which in turn defines `HAVE_STRTOF 1`. `avr-gcc` doesn't have `strtof`, so this results in a compile error.  Setting `HAVE_STRTOF  0` fixes this.

The second fix is to prevent a compiler warning with `USE_COMMAND_TAGS 0`. The `SCPI_CMD_LIST_END` token has a command tag, which causes an _excess elements in struct initializer_ warning. My fix is to define an alternate token without the tag if command tags are not being used.