### PR TITLE
Don't reference malloc if not using alloc/free

### DIFF
--- a/libscpi/src/utils.c
+++ b/libscpi/src/utils.c
@@ -752,7 +752,7 @@ int OUR_strncasecmp(const char *s1, const char *s2, size_t n) {
 }
 #endif
 
-#if !HAVE_STRNDUP
+#if USE_MEMORY_ALLOCATION_FREE && !HAVE_STRNDUP
 char *OUR_strndup(const char *s, size_t n) {
     size_t len = SCPIDEFINE_strnlen(s, n);
     char * result = malloc(len + 1);


### PR DESCRIPTION
The `OUR_strndup` function is only referenced when `USE_MEMORY_ALLOCATION_FREE` is set (line 217 of `inc/scpi/config.h`). However, if malloc is not available, `utils.c` fails to compile even though `OUR_strndup` will never be used. This PR ensures that malloc is only referenced when using libc's malloc/free.