### PR TITLE
fixed typo FAGRENHEIT should be FAHRENHEIT

### DIFF
--- a/libscpi/inc/scpi/types.h
+++ b/libscpi/inc/scpi/types.h
@@ -281,7 +281,7 @@ extern "C" {
         SCPI_UNIT_BAR,
         SCPI_UNIT_DECIBEL,
         SCPI_UNIT_UNITLESS,
-        SCPI_UNIT_FAGRENHEIT,
+        SCPI_UNIT_FAHRENHEIT,
         SCPI_UNIT_KELVIN,
         SCPI_UNIT_DAY,
         SCPI_UNIT_YEAR,

--- a/libscpi/src/units.c
+++ b/libscpi/src/units.c
@@ -248,7 +248,7 @@ const scpi_unit_def_t scpi_units_def[] = {
     /* Temperature */
     {/* name */ "CEL", /* unit */ SCPI_UNIT_CELSIUS, /* mult */ 1},
 #if USE_UNITS_IMPERIAL
-    {/* name */ "FAR", /* unit */ SCPI_UNIT_FAGRENHEIT, /* mult */ 1},
+    {/* name */ "FAR", /* unit */ SCPI_UNIT_FAHRENHEIT, /* mult */ 1},
 #endif /* USE_UNITS_IMPERIAL */
     {/* name */ "K", /* unit */ SCPI_UNIT_KELVIN, /* mult */ 1},
 #endif /* USE_UNITS_TEMPERATURE */


### PR DESCRIPTION
For now I have only this typo fix.

I will work on SCPI for about 2 months so I will probably have more fixes.

For example angle units for **degrees** and **radians** have the same multiplication factor **1** now, which I think makes the conversion between the two wrong.