### PR TITLE
moving bool choice definition (ON, OFF) to units.c

### DIFF
--- a/libscpi/inc/scpi/units.h
+++ b/libscpi/inc/scpi/units.h
@@ -45,6 +45,7 @@ extern "C" {
 
     extern const scpi_unit_def_t scpi_units_def[];
     extern const scpi_choice_def_t scpi_special_numbers_def[];
+    extern const scpi_choice_def_t scpi_bool_def[];
 
     scpi_bool_t SCPI_ParamNumber(scpi_t * context, const scpi_choice_def_t * special, scpi_number_t * value, scpi_bool_t mandatory);
 

--- a/libscpi/src/parser.c
+++ b/libscpi/src/parser.c
@@ -44,6 +44,7 @@
 #include "scpi/error.h"
 #include "scpi/constants.h"
 #include "scpi/utils.h"
+#include "scpi/units.h"
 
 /**
  * Write data to SCPI output
@@ -1282,12 +1283,6 @@ scpi_bool_t SCPI_ParamBool(scpi_t * context, scpi_bool_t * value, scpi_bool_t ma
     scpi_parameter_t param;
     int32_t intval;
 
-    scpi_choice_def_t bool_options[] = {
-        {"OFF", 0},
-        {"ON", 1},
-        SCPI_CHOICE_LIST_END /* termination of option list */
-    };
-
     if (!value) {
         SCPI_ErrorPush(context, SCPI_ERROR_SYSTEM_ERROR);
         return FALSE;
@@ -1300,7 +1295,7 @@ scpi_bool_t SCPI_ParamBool(scpi_t * context, scpi_bool_t * value, scpi_bool_t ma
             SCPI_ParamToInt32(context, &param, &intval);
             *value = intval ? TRUE : FALSE;
         } else {
-            result = SCPI_ParamToChoice(context, &param, bool_options, &intval);
+            result = SCPI_ParamToChoice(context, &param, scpi_bool_def, &intval);
             if (result) {
                 *value = intval ? TRUE : FALSE;
             }

--- a/libscpi/src/units.c
+++ b/libscpi/src/units.c
@@ -285,6 +285,15 @@ const scpi_choice_def_t scpi_special_numbers_def[] = {
     SCPI_CHOICE_LIST_END,
 };
 
+/*
+ * Special number values definition
+ */
+const scpi_choice_def_t scpi_bool_def[] = {
+    {"OFF", 0},
+    {"ON", 1},
+    SCPI_CHOICE_LIST_END /* termination of option list */
+};
+
 /**
  * Convert string describing unit to its representation
  * @param units units patterns


### PR DESCRIPTION
The (ON, OFF) Boolean choices are standard and should be available to users.

I expected `SCPI_ResultBool` to return mnemonics, since otherwise SCPI_ResultUInt32() would be the obvious equivalent. Other then the obvious breaking of backward compatibility, what do you think?

I am now using this code to translate into mnemonics:
```
    const char * text;
    if(!SCPI_ChoiceToName(scpi_bool_def, value, &text)){
        return SCPI_RES_ERR;
    }
    SCPI_ResultMnemonic(context, text);
```