### PR TITLE
Prevent undefined macro and unused argument warnings in bare metal environments

### DIFF
--- a/libscpi/inc/scpi/cc.h
+++ b/libscpi/inc/scpi/cc.h
@@ -54,37 +54,57 @@ extern "C" {
 # endif
 #endif
 
-#if POSIX_C_SOURCE >= 200809L || _XOPEN_SOURCE >= 700
+#if (defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 200809L) || \
+    (defined _XOPEN_SOURCE && _XOPEN_SOURCE >= 700)
     #define HAVE_STRNDUP 1
     #define HAVE_STRNLEN 1
 #endif
 
-#if _BSD_SOURCE || _XOPEN_SOURCE >= 500 || _ISOC99_SOURCE || _POSIX_C_SOURCE >= 200112L || C99
+#if (defined _BSD_SOURCE && _BSD_SOURCE) || \
+    (defined _XOPEN_SOURCE  && _XOPEN_SOURCE >= 500) || \
+    (defined _ISOC99_SOURCE && _ISOC99_SOURCE) || \
+    (defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 200112L) || \
+    C99
     #define HAVE_SNPRINTF 1
 #endif
 
-#if _POSIX_C_SOURCE >= 200112L
+#if (defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 200112L) 
     #define HAVE_STRNCASECMP 1
 #endif
 
-#if _BSD_SOURCE || _SVID_SOURCE || _XOPEN_SOURCE || _ISOC99_SOURCE || _POSIX_C_SOURCE >= 200112L || C99
+#if (defined _BSD_SOURCE && _BSD_SOURCE) || \
+    (defined _SVID_SOURCE && _SVID_SOURCE) || \
+    (defined _XOPEN_SOURCE && _XOPEN_SOURCE) || \
+    (defined _ISOC99_SOURCE && _ISOC99_SOURCE) || \
+    (defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 200112L) ||\
+    C99
     #define HAVE_ISNAN 1
 #endif
 
-#if _XOPEN_SOURCE >= 600 || _ISOC99_SOURCE || _POSIX_C_SOURCE >= 200112L || C99
+#if (defined _XOPEN_SOURCE && _XOPEN_SOURCE >= 600)|| \
+    (defined _ISOC99_SOURCE && _ISOC99_SOURCE) || \
+    (defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 200112L) || \
+    C99
     #define HAVE_ISFINITE 1
     #define HAVE_SIGNBIT 1
 #endif
 
-#if XOPEN_SOURCE >= 600 || _BSD_SOURCE || _SVID_SOURCE || _ISOC99_SOURCE || _POSIX_C_SOURCE >= 200112L
+#if (defined _XOPEN_SOURCE && XOPEN_SOURCE >= 600) || \
+    (defined _BSD_SOURCE && _BSD_SOURCE) || \
+    (defined _SVID_SOURCE && _SVID_SOURCE) || \
+    (defined _ISOC99_SOURCE && _ISOC99_SOURCE) || \
+    (defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 200112L)
     #define HAVE_STRTOLL 1
 #endif
 
-#if _XOPEN_SOURCE >= 600 || _ISOC99_SOURCE || _POSIX_C_SOURCE >= 200112L || C99
+#if (defined _XOPEN_SOURCE && _XOPEN_SOURCE >= 600) || \
+    (defined _ISOC99_SOURCE && _ISOC99_SOURCE) || \
+    (defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 200112L) || \
+    C99
     #define HAVE_STRTOF 1
 #endif
 
-#if _ISOC99_SOURCE || C99
+#if (defined _ISOC99_SOURCE && _ISOC99_SOURCE) || C99
     #define HAVE_STDBOOL 1
 #endif
 
@@ -130,6 +150,10 @@ extern "C" {
 #define HAVE_STRDUP             0
 #endif
 
+#ifndef HAVE_STRNDUP
+#define HAVE_STRNDUP             0
+#endif
+
 #ifndef HAVE_STRNICMP
 #define HAVE_STRNICMP           0
 #endif
@@ -168,6 +192,10 @@ extern "C" {
 
 #ifndef HAVE_STRTOF
 #define HAVE_STRTOF             0
+#endif
+
+#ifndef  HAVE_DTOSTRE
+#define  HAVE_DTOSTRE           0 
 #endif
 
 #ifdef	__cplusplus

--- a/libscpi/inc/scpi/config.h
+++ b/libscpi/inc/scpi/config.h
@@ -100,6 +100,10 @@ extern "C" {
 #ifndef USE_MEMORY_ALLOCATION_FREE
 #define USE_MEMORY_ALLOCATION_FREE 1
 #endif
+#else
+#ifndef USE_MEMORY_ALLOCATION_FREE
+#define USE_MEMORY_ALLOCATION_FREE 0
+#endif
 #endif
 
 #ifndef USE_COMMAND_TAGS
@@ -110,8 +114,8 @@ extern "C" {
 #define USE_DEPRECATED_FUNCTIONS 1
 #endif
 
-#ifndef USE_CUSTOM_DTOSTR
-#define USE_CUSTOM_DTOSTR 0
+#ifndef USE_CUSTOM_DTOSTRE
+#define USE_CUSTOM_DTOSTRE 0
 #endif
 
 #ifndef USE_UNITS_IMPERIAL

--- a/libscpi/src/error.c
+++ b/libscpi/src/error.c
@@ -130,6 +130,9 @@ int32_t SCPI_ErrorCount(scpi_t * context) {
 
 static scpi_bool_t SCPI_ErrorAddInternal(scpi_t * context, int16_t err, char * info, size_t info_len) {
     scpi_error_t error_value;
+    /* SCPIDEFINE_strndup is sometimes a dumy that does not reference it's arguments. 
+       Since info_len is not referenced elsewhere caoing to void prevents unusd argument warnings */
+    (void) info_len;
     char * info_ptr = info ? SCPIDEFINE_strndup(&context->error_info_heap, info, info_len) : NULL;
     SCPI_ERROR_SETVAL(&error_value, err, info_ptr);
     if (!fifo_add(&context->error_queue, &error_value)) {


### PR DESCRIPTION
When compiling on bare metal environments, e.g. arm-none-eabi-gcc I get a large number of warnings from cc.h due to the way configuration macros are evaluated. This PR adds checks to make sure they are defined before using them. I'm not using the included Makefile in this case, just compiling the C files directly from my projects Makefile. 

It also fixes an unused argument warning in bare metal builds where SCPIDEFINE_strndup
doesn't evaluate its arguments.