### PR TITLE
IEEE 488.2 Annex A.1.2: Enhanced tree walking implementation (prohibited by SCPI-99)

### DIFF
--- a/libscpi/src/parser.c
+++ b/libscpi/src/parser.c
@@ -206,9 +206,13 @@ scpi_bool_t SCPI_Parse(scpi_t * context, char * data, int len) {
             result = FALSE;
         } else if (state->programHeader.len > 0) {
 
-            composeCompoundCommand(&cmd_prev, &state->programHeader);
-
-            if (findCommandHeader(context, state->programHeader.ptr, state->programHeader.len)) {
+            if ( findCommandHeader(context, state->programHeader.ptr, state->programHeader.len) || 
+                 ( composeCompoundCommand(&cmd_prev, &state->programHeader) && 
+                   findCommandHeader(context, state->programHeader.ptr, state->programHeader.len)
+                 ) /* to comply with section 7.6.1.5, first check if the current message is a valid program message,
+                    * and perform compoundCommand check only if it is not. 
+                    */
+               ) {
 
                 context->param_list.lex_state.buffer = state->programData.ptr;
                 context->param_list.lex_state.pos = context->param_list.lex_state.buffer;

--- a/libscpi/test/test_parser.c
+++ b/libscpi/test/test_parser.c
@@ -285,6 +285,9 @@ static void testCommandsHandling(void) {
     TEST_INPUT("TEST:TREEA?;:TEXT? \"PARAM1\", \"PARAM2\"\r\n", "10;\"PARAM2\"\r\n");
     output_buffer_clear();
 
+    TEST_INPUT("TEST:TREEA?;TEXT? \"PARAM1\", \"PARAM2\"\r\n", "10;\"PARAM2\"\r\n"); /* valid according to IEEE 488 Annex A.1 */
+    output_buffer_clear();
+
     /* Test special characters in parameters */
     TEST_INPUT("TEXT? \"\", \"test\r\n\"\r\n", "\"test\r\n\"\r\n");
     output_buffer_clear();


### PR DESCRIPTION
Hi,

Thanks for this nice library! While writing a SCPI translator to substitute some equipment in a legacy application, I found a little issue with a command similar to this:

MEAS:CUR?;MEAS:VOL?;MEAS:POW?;OUTP?

libscpi woud mistake the second unit for a compound command MEAS:MEAS:VOL and emit an error.

I found in Annex A.1 of the IEE488-2 standard some example commands that are similar to my case, so I assume these are legal. However, I do not know the standard well enough to judge if my solution is the correct approach.

Best regards,
Thomas Seiler

----- commit message -----
Not all program messages with several program message units are compound statements. 
Currently the parser uses hints like the colon or asterisk at the beginning of the next command to determine whether or not the next program message unit should be treated as compound command.

The approach fails for sequences of valid device specific commands unless they start with colons. Consider:

TREE:TESTA?; TEXT?

In this case , second unit is treated as compound command "TREE:TEXT?" which would not exist.

Therefore modify the parser to first check if the unit is a valid program message as it stands, before
handling it as compound command