### PR TITLE
Fix event commands adding semi-colons to output

### DIFF
--- a/libscpi/inc/scpi/types.h
+++ b/libscpi/inc/scpi/types.h
@@ -371,6 +371,7 @@ extern "C" {
         scpi_interface_t * interface;
         int_fast16_t output_count;
         int_fast16_t input_count;
+        scpi_bool_t first_output;
         scpi_bool_t cmd_error;
         scpi_fifo_t error_queue;
 #if USE_DEVICE_DEPENDENT_ERROR_INFORMATION && !USE_MEMORY_ALLOCATION_FREE

--- a/libscpi/test/test_parser.c
+++ b/libscpi/test/test_parser.c
@@ -257,6 +257,9 @@ static void testCommandsHandling(void) {
     TEST_INPUT("*IDN?;*IDN?;*IDN?;*IDN?\r\n", "MA,IN,0,VER;MA,IN,0,VER;MA,IN,0,VER;MA,IN,0,VER\r\n");
     output_buffer_clear();
 
+    TEST_INPUT("*IDN?;STUB\r\n", "MA,IN,0,VER\r\n");
+    output_buffer_clear();
+
     TEST_INPUT("*IDN?;*OPC;*IDN?\r\n", "MA,IN,0,VER;MA,IN,0,VER\r\n");
     output_buffer_clear();
 


### PR DESCRIPTION
Prior to this fix having a event-only command follow a query
command will result in a semi-colon being added to the output despite
the event-only command not writing any sort of output.