### PR TITLE
Doc fixes: `scpi_context_t` → `scpi_t` and `int16_t` → `scpi_error_t` where required

### DIFF
--- a/_api/SCPI_ErrorPop.md
+++ b/_api/SCPI_ErrorPop.md
@@ -4,9 +4,11 @@ category: errors
 ---
 
 ```c
-int16_t
+scpi_bool_t
 SCPI_ErrorPop(
-    scpi_t * context);
+    scpi_t * context,
+    scpi_error_t * error);
 ```
 
-Remove error from queue and return its value.
+Remove error from queue and place it in `error`.
+Return `TRUE` on success, `FALSE` on failure.

--- a/_api/SCPI_Init.md
+++ b/_api/SCPI_Init.md
@@ -11,7 +11,7 @@ void SCPI_Init(scpi_t * context,
     const scpi_unit_def_t * units,
     const char * idn1, const char * idn2, const char * idn3, const char * idn4,
     char * input_buffer, size_t input_buffer_length,
-    int16_t * error_queue_data, int16_t error_queue_size);
+    scpi_error_t * error_queue_data, int16_t error_queue_size);
 ```
 
 Function to initialise the parser. All parameters must be prealocated before calling this function. It just registers these values to context.

--- a/_basic/instrument.md
+++ b/_basic/instrument.md
@@ -72,7 +72,7 @@ while(1) {
 There is also need to allocate error queue. This can be done by
 ```c
 #define SCPI_ERROR_QUEUE_SIZE 17
-int16_t scpi_error_queue_data[SCPI_ERROR_QUEUE_SIZE];
+scpi_error_t scpi_error_queue_data[SCPI_ERROR_QUEUE_SIZE];
 ```
 
 SCPI parser context

--- a/_basic/instrument.md
+++ b/_basic/instrument.md
@@ -36,7 +36,7 @@ scpi_interface_t scpi_interface = {
 Test implementation of function myWrite, which outputs everything to stdout, can be
 
 ```c    
-size_t myWrite(scpi_context_t * context, const char * data, size_t len) {
+size_t myWrite(scpi_t * context, const char * data, size_t len) {
     (void) context;
     return fwrite(data, 1, len, stdout);
 }


### PR DESCRIPTION
As a new user of this library, I stumbled over two incorrect types in the [“basic instrument” docs](https://www.jaybee.cz/scpi-parser/basic/instrument/). This pull request fixes these.

The API docs for `SCPI_ErrorPop` and `SCPI_Init` were also outdated, fixed these as well.