### PR TITLE
make scpi port and events (connected, error) usable in project

### DIFF
--- a/examples/common/scpi-def.h
+++ b/examples/common/scpi-def.h
@@ -28,6 +28,9 @@
 
 #ifndef __SCPI_DEF_H_
 #define __SCPI_DEF_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "scpi/scpi.h"
 
@@ -53,5 +56,8 @@ scpi_result_t SCPI_Flush(scpi_t * context);
 
 scpi_result_t SCPI_SystemCommTcpipControlQ(scpi_t * context);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* __SCPI_DEF_H_ */
 

--- a/examples/test-LwIP-netconn/scpi_server.c
+++ b/examples/test-LwIP-netconn/scpi_server.c
@@ -49,10 +49,6 @@
 #include "lwip/tcp.h"
 #include "lwip/inet.h"
 
-
-#define DEVICE_PORT 5025
-#define CONTROL_PORT 5026
-
 #define SCPI_THREAD_PRIO (tskIDLE_PRIORITY + 2)
 
 #define SCPI_MSG_TIMEOUT                0
@@ -152,7 +148,7 @@ scpi_result_t SCPI_Reset(scpi_t * context) {
 }
 
 scpi_result_t SCPI_SystemCommTcpipControlQ(scpi_t * context) {
-    SCPI_ResultInt(context, CONTROL_PORT);
+    SCPI_ResultInt(context, SCPI_CONTROL_PORT);
     return SCPI_RES_OK;
 }
 
@@ -379,10 +375,10 @@ static void scpi_server_thread(void *arg) {
 
     scpi_context.user_context = &user_data;
 
-    user_data.io_listen = createServer(DEVICE_PORT);
+    user_data.io_listen = createServer(SCPI_DEVICE_PORT);
     LWIP_ASSERT("user_data.io_listen != NULL", user_data.io_listen != NULL);
 
-    user_data.control_io_listen = createServer(CONTROL_PORT);
+    user_data.control_io_listen = createServer(SCPI_CONTROL_PORT);
     LWIP_ASSERT("user_data.control_io_listen != NULL", user_data.control_io_listen != NULL);
 
     while (1) {

--- a/examples/test-LwIP-netconn/scpi_server.c
+++ b/examples/test-LwIP-netconn/scpi_server.c
@@ -262,7 +262,7 @@ static int processSrqIoListen(scpi_t * context, user_data_t * user_data) {
             netconn_delete(newconn);
         } else {
             /* control connection established */
-			SCPI_Event_ControlConnected(context, newconn);
+            SCPI_Event_ControlConnected(context, newconn);
             user_data->control_io = newconn;
         }
     }
@@ -272,7 +272,7 @@ static int processSrqIoListen(scpi_t * context, user_data_t * user_data) {
 
 static void closeIo(scpi_t * context, user_data_t * user_data) {
     /* connection closed */
-	SCPI_Event_DeviceDisconnected(context, user_data->io);
+    SCPI_Event_DeviceDisconnected(context, user_data->io);
     netconn_close(user_data->io);
     netconn_delete(user_data->io);
     user_data->io = NULL;
@@ -280,7 +280,7 @@ static void closeIo(scpi_t * context, user_data_t * user_data) {
 
 static void closeSrqIo(scpi_t * context, user_data_t * user_data) {
     /* control connection closed */
-	SCPI_Event_ControlDisconnected(context, user_data->io);
+    SCPI_Event_ControlDisconnected(context, user_data->io);
     netconn_close(user_data->control_io);
     netconn_delete(user_data->control_io);
     user_data->control_io = NULL;
@@ -423,34 +423,34 @@ void scpi_server_init(void) {
 
 /* Called by processIoListen() for additional reporting. Override on demand. */
 void __attribute__((weak)) SCPI_Event_DeviceConnected(scpi_t * context, struct netconn * conn) {
-	iprintf("***Connection established %s\r\n", inet_ntoa(newconn->pcb.ip->remote_ip));
+    iprintf("***Connection established %s\r\n", inet_ntoa(newconn->pcb.ip->remote_ip));
     /* Remote or Eth LED ON */
 }
 
 /* Called by closeIO() for additional reporting. Override on demand. */
 void __attribute__((weak)) SCPI_Event_DeviceDisconnected(scpi_t * context, struct netconn * conn) {
-	iprintf("***Connection closed\r\n");
+    iprintf("***Connection closed\r\n");
     /* Remote or Eth LED OFF */
 }
 
 /* Called by processIoListen() for additional reporting. Override on demand. */
 void __attribute__((weak)) SCPI_Event_ControlConnected(scpi_t * context, struct netconn * conn) {
-	iprintf("***Control Connection established %s\r\n", inet_ntoa(newconn->pcb.ip->remote_ip));
+    iprintf("***Control Connection established %s\r\n", inet_ntoa(newconn->pcb.ip->remote_ip));
 }
 
 /* Called by closeIO() for additional reporting. Override on demand. */
 void __attribute__((weak)) SCPI_Event_ControlDisconnected(scpi_t * context, struct netconn * conn) {
-	iprintf("***Control Connection closed\r\n");
+    iprintf("***Control Connection closed\r\n");
 }
 
 /* Called by SCPI_Error() for reporting. Override on demand. */
 void __attribute__((weak)) SCPI_Event_ErrorIndicatorOn(scpi_t * context, int_fast16_t err) {
-	iprintf("**ERROR: %ld, \"%s\"\r\n", (int32_t) err, SCPI_ErrorTranslate(err));
+    iprintf("**ERROR: %ld, \"%s\"\r\n", (int32_t) err, SCPI_ErrorTranslate(err));
     /* New error : BEEP, Error LED ON */
 }
 
 /* Called by SCPI_Error() for reporting. Override on demand. */
 void __attribute__((weak)) SCPI_Event_ErrorIndicatorOff(scpi_t * context, int_fast16_t err) {
-	iprintf("**ERROR: %ld, \"%s\"\r\n", (int32_t) err, SCPI_ErrorTranslate(err));
+    iprintf("**ERROR: %ld, \"%s\"\r\n", (int32_t) err, SCPI_ErrorTranslate(err));
     /* No more errors in the queue : Error LED OFF */
 }

--- a/examples/test-LwIP-netconn/scpi_server.h
+++ b/examples/test-LwIP-netconn/scpi_server.h
@@ -32,6 +32,9 @@
 extern "C" {
 #endif
 
+#define SCPI_DEVICE_PORT  5025 // scpi-raw standard port
+#define SCPI_CONTROL_PORT 5026 // libscpi control port (not part of the standard)
+
 #include <stdint.h>
 
 void scpi_server_init(void);

--- a/examples/test-LwIP-netconn/scpi_server.h
+++ b/examples/test-LwIP-netconn/scpi_server.h
@@ -36,7 +36,7 @@ extern "C" {
 #define SCPI_CONTROL_PORT 5026 // libscpi control port (not part of the standard)
 
 #include <stdint.h>
-#include "api.h"
+#include "lwip/api.h"
 #include "scpi/types.h"
 
 void scpi_server_init(void);
@@ -45,8 +45,10 @@ void SCPI_AddError(int16_t err);
 void SCPI_RequestControl(void);
 
 // optional event handlers
-void SCPI_Event_DeviceConnected(struct netconn * conn);
-void SCPI_Event_DeviceDisconnected(struct netconn * conn);
+void SCPI_Event_DeviceConnected(scpi_t * context, struct netconn * conn);
+void SCPI_Event_DeviceDisconnected(scpi_t * context, struct netconn * conn);
+void SCPI_Event_ControlConnected(scpi_t * context, struct netconn * conn);
+void SCPI_Event_ControlDisconnected(scpi_t * context, struct netconn * conn);
 void SCPI_Event_ErrorIndicatorOn(scpi_t * context, int_fast16_t err);
 void SCPI_Event_ErrorIndicatorOff(scpi_t * context, int_fast16_t err);
 

--- a/examples/test-LwIP-netconn/scpi_server.h
+++ b/examples/test-LwIP-netconn/scpi_server.h
@@ -28,7 +28,9 @@
 
 #ifndef _SCPI_SERVER_H_
 #define _SCPI_SERVER_H_
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stdint.h>
 
@@ -37,5 +39,7 @@ void scpi_server_init(void);
 void SCPI_AddError(int16_t err);
 void SCPI_RequestControl(void);
 
-
+#ifdef __cplusplus
+}
+#endif
 #endif /* _SCPI_SERVER_H_ */

--- a/examples/test-LwIP-netconn/scpi_server.h
+++ b/examples/test-LwIP-netconn/scpi_server.h
@@ -36,6 +36,8 @@ extern "C" {
 #define SCPI_CONTROL_PORT 5026 // libscpi control port (not part of the standard)
 
 #include <stdint.h>
+#include "api.h"
+#include "scpi/types.h"
 
 void scpi_server_init(void);
 

--- a/examples/test-LwIP-netconn/scpi_server.h
+++ b/examples/test-LwIP-netconn/scpi_server.h
@@ -42,6 +42,12 @@ void scpi_server_init(void);
 void SCPI_AddError(int16_t err);
 void SCPI_RequestControl(void);
 
+// optional event handlers
+void SCPI_Event_DeviceConnected(struct netconn * conn);
+void SCPI_Event_DeviceDisconnected(struct netconn * conn);
+void SCPI_Event_ErrorIndicatorOn(scpi_t * context, int_fast16_t err);
+void SCPI_Event_ErrorIndicatorOff(scpi_t * context, int_fast16_t err);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
* move DEVICE_PORT and SERVER_PORT to header
* add weak event handlers for accepted / closed connections and error indication

After copying scpi-parser files into a project and working with the LWIP-netconn example for a few months, this is the first of perhaps a few PRs with bug fixes and enhancements introduced to an scpi-parser fork in a hopefully clean manner to offer them to the community.

I'm using the event handlers in question to turn on  / off user LEDs on a Nucleo-F767ZI board.