### PR TITLE
fix corrupted compound command results

### DIFF
--- a/examples/test-LwIP-netconn/scpi_server.c
+++ b/examples/test-LwIP-netconn/scpi_server.c
@@ -94,7 +94,7 @@ size_t SCPI_Write(scpi_t * context, const char * data, size_t len) {
     if (context->user_context != NULL) {
         user_data_t * u = (user_data_t *) (context->user_context);
         if (u->io) {
-            return (netconn_write(u->io, data, len, NETCONN_NOCOPY) == ERR_OK) ? len : 0;
+            return (netconn_write(u->io, data, len, NETCONN_COPY) == ERR_OK) ? len : 0;
         }
     }
     return 0;
@@ -139,7 +139,7 @@ scpi_result_t SCPI_Control(scpi_t * context, scpi_ctrl_name_t ctrl, scpi_reg_val
         user_data_t * u = (user_data_t *) (context->user_context);
         if (u->control_io) {
             snprintf(b, sizeof (b), "SRQ%d\r\n", val);
-            return netconn_write(u->control_io, b, strlen(b), NETCONN_NOCOPY) == ERR_OK ? SCPI_RES_OK : SCPI_RES_ERR;
+            return netconn_write(u->control_io, b, strlen(b), NETCONN_COPY) == ERR_OK ? SCPI_RES_OK : SCPI_RES_ERR;
         }
     }
     return SCPI_RES_OK;


### PR DESCRIPTION
When compound commands are used, e.g. in a scenario where the application controls hardware with multiple channels we found that some some parts go missing. *IDN?;*IDN? works, other queries that would return "0;1;2" only return "0;".

**fix:**
use netconn_write(u->io, data, len, **NETCONN_COPY**). NETCONN_NOCOPY is not allowed here, as data doesn't stay valid until sending is complete. See https://doc.ecoscentric.com/ref/lwip-api-sequential-netconn-write.html for details.

**enhancement:**
provide SCPI_ResultCommand() to facilitate prepending results with the command in question.

example: MEAS:VOLT:CH1?;CH2?;CH3?;CH4?:MEAS:CURR:CH1?
reply (prepend on): MEAS:VOLT:CH1,0.123;MEAS:VOLT:CH2,2.048;MEAS:VOLT:CH3,1.337;MEAS:VOLT:CH4,0;:MEAS:CURR:CH1,0.42
reply (default): 0.123;2.048;1.337;0;0.42
