### PR TITLE
set keep-alive defaults for new connections

### DIFF
--- a/examples/test-LwIP-netconn/scpi_server.c
+++ b/examples/test-LwIP-netconn/scpi_server.c
@@ -253,6 +253,10 @@ static int processIoListen(user_data_t * user_data) {
         } else {
             /* connection established */
             iprintf("***Connection established %s\r\n", inet_ntoa(newconn->pcb.ip->remote_ip));
+            newconn->pcb.tcp->so_options |= SOF_KEEPALIVE;
+            newconn->pcb.tcp->keep_idle   = SCPI_KEEP_IDLE;  // Override TCP_KEEPIDLE_DEFAULT  for this connection.
+            newconn->pcb.tcp->keep_intvl  = SCPI_KEEP_INTVL; // Override TCP_KEEPINTVL_DEFAULT for this connection.
+            newconn->pcb.tcp->keep_cnt    = SCPI_KEEP_CNT;   // Override TCP_KEEPCNT_DEFAULT   for this connection.
             user_data->io = newconn;
         }
     }
@@ -270,6 +274,10 @@ static int processSrqIoListen(user_data_t * user_data) {
         } else {
             /* control connection established */
             iprintf("***Control Connection established %s\r\n", inet_ntoa(newconn->pcb.ip->remote_ip));
+            newconn->pcb.tcp->so_options |= SOF_KEEPALIVE;
+            newconn->pcb.tcp->keep_idle   = SCPI_KEEP_IDLE;  // Override TCP_KEEPIDLE_DEFAULT  for this connection.
+            newconn->pcb.tcp->keep_intvl  = SCPI_KEEP_INTVL; // Override TCP_KEEPINTVL_DEFAULT for this connection.
+            newconn->pcb.tcp->keep_cnt    = SCPI_KEEP_CNT;   // Override TCP_KEEPCNT_DEFAULT   for this connection.
             user_data->control_io = newconn;
         }
     }

--- a/examples/test-LwIP-netconn/scpi_server.c
+++ b/examples/test-LwIP-netconn/scpi_server.c
@@ -253,7 +253,7 @@ static int processIoListen(user_data_t * user_data) {
         } else {
             /* connection established */
             iprintf("***Connection established %s\r\n", inet_ntoa(newconn->pcb.ip->remote_ip));
-            newconn->pcb.tcp->so_options |= SOF_KEEPALIVE;
+            ip_set_option(newconn->pcb.tcp, SOF_KEEPALIVE);
             newconn->pcb.tcp->keep_idle   = SCPI_KEEP_IDLE;  // Override TCP_KEEPIDLE_DEFAULT  for this connection.
             newconn->pcb.tcp->keep_intvl  = SCPI_KEEP_INTVL; // Override TCP_KEEPINTVL_DEFAULT for this connection.
             newconn->pcb.tcp->keep_cnt    = SCPI_KEEP_CNT;   // Override TCP_KEEPCNT_DEFAULT   for this connection.
@@ -274,7 +274,7 @@ static int processSrqIoListen(user_data_t * user_data) {
         } else {
             /* control connection established */
             iprintf("***Control Connection established %s\r\n", inet_ntoa(newconn->pcb.ip->remote_ip));
-            newconn->pcb.tcp->so_options |= SOF_KEEPALIVE;
+            ip_set_option(newconn->pcb.tcp, SOF_KEEPALIVE);
             newconn->pcb.tcp->keep_idle   = SCPI_KEEP_IDLE;  // Override TCP_KEEPIDLE_DEFAULT  for this connection.
             newconn->pcb.tcp->keep_intvl  = SCPI_KEEP_INTVL; // Override TCP_KEEPINTVL_DEFAULT for this connection.
             newconn->pcb.tcp->keep_cnt    = SCPI_KEEP_CNT;   // Override TCP_KEEPCNT_DEFAULT   for this connection.

--- a/examples/test-LwIP-netconn/scpi_server.h
+++ b/examples/test-LwIP-netconn/scpi_server.h
@@ -29,6 +29,9 @@
 #ifndef _SCPI_SERVER_H_
 #define _SCPI_SERVER_H_
 
+#define SCPI_KEEP_IDLE    2000 // (ms) keepalive quiet time after last TCP packet
+#define SCPI_KEEP_INTVL   1000 // (ms) keepalive repeat interval
+#define SCPI_KEEP_CNT        4 // Retry count before terminating connection (SCPI_KEEP_INTVL * SCPI_KEEP_INTVL (ms)).
 
 #include <stdint.h>
 


### PR DESCRIPTION
Configure scpi-specific keep-alive settings for new connections. Without these, a connection lost on the client side blocks the server baiscally indefinitely, requiring a reset or some means to recover via another port or interface.

scpi server connection timeout is chosen such that when idle, zero window probes are sent periodically, and the connection is closed when they fail SCPI\_KEEP\_CNT times.

To change the defaults for all connections, add these values (lwipopts.h):

```
#define  TCP_KEEPIDLE_DEFAULT   15000UL /* Default KEEPALIVE timer in milliseconds */
#define  TCP_KEEPINTVL_DEFAULT   5000UL /* Default Time between KEEPALIVE probes in milliseconds */
#define  TCP_KEEPCNT_DEFAULT        3U  /* Default Counter for KEEPALIVE probes */
```

---

For keep-alive settings to be used, keep-alive needs to be enabled, and LwIP timers need to be used.

in lwipopts.h:
```
#define LWIP_TCP_KEEPALIVE 1
```

To allow LwIP timer operation, set (in opt.h or lwipopts.h):
```
#define LWIP_TIMERS 1 
```
(also requires FreeRTOS USE\_TIMERS 1 or, for non-OS implementations, calling sys\_check\_timeouts() in the main loop).

tcp\_priv.h ` tcp_tmr();` is called every 250 ms to keep track of timeouts, which is handled internally.

---

Also note: when other connections are used (e.g. http server listening socket), revisit memory pool sizes (lwipopts.h):
```
#define MEMP_NUM_NETCONN 10
```
(default is 4, which can be exhausted by scpi server when two connections are active on top of the two listening socket protocol control block (pcb) structs which stay allocated.