### PR TITLE
output block data with delimiter

### DIFF
--- a/libscpi/inc/scpi/types.h
+++ b/libscpi/inc/scpi/types.h
@@ -50,7 +50,7 @@
 extern "C" {
 #endif
 
-#if !HAVE_STDBOOL
+#if (!HAVE_STDBOOL) && (!_GLIBCXX_HAVE_STDBOOL_H)
     typedef unsigned char bool;
 #endif
 
@@ -354,7 +354,7 @@ extern "C" {
 #if USE_COMMAND_TAGS
         int32_t tag;
 #endif /* USE_COMMAND_TAGS */
-    };
+};
 
     struct _scpi_interface_t {
         scpi_error_callback_t error;
@@ -381,7 +381,7 @@ extern "C" {
         void * user_context;
         scpi_parser_state_t parser_state;
         const char * idn[4];
-        size_t arbitrary_reminding;
+        size_t arbitrary_remaining;
     };
 
     enum _scpi_array_format_t {


### PR DESCRIPTION
scpi-99 6.2.3.4 and 6.2.6 suggest returning multiple blocks is valid. SCPI_ResultArbitraryBlockHeader() would need to insert a delimiter.

Other changes are: testing for _GLIBCXX_HAVE_STDBOOL_H (see https://github.com/j123b567/scpi-parser/issues/116), testing for non-NULL data in writeData(), and some spelling fixes.