### PR TITLE
introduce SCPI_HelpQ with descriptions

### DIFF
--- a/examples/common/scpi-def.c
+++ b/examples/common/scpi-def.c
@@ -353,7 +353,22 @@ static scpi_result_t My_CoreTstQ(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+#if USE_COMMAND_DESCRIPTIONS
+#define SCPI_CMD_DESC(S) .description=(S),
+#else
+#define SCPI_CMD_DESC(S)
+#endif
+
+#if USE_COMMAND_TAGS
+#define SCPI_CMD_TAG(T) .tag=(T),
+#else
+#define SCPI_CMD_TAG(T)
+#endif
+
 const scpi_command_t scpi_commands[] = {
+    /* Optional help commmand */
+    {.pattern = "HELP?", .callback = SCPI_HelpQ, SCPI_CMD_DESC("\t - list supported commands")},
+	
     /* IEEE Mandated Commands (SCPI std V1999.0 4.1.1) */
     { .pattern = "*CLS", .callback = SCPI_CoreCls,},
     { .pattern = "*ESE", .callback = SCPI_CoreEse,},

--- a/examples/common/scpi-def.cpp
+++ b/examples/common/scpi-def.cpp
@@ -353,60 +353,75 @@ static scpi_result_t My_CoreTstQ(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+#if USE_COMMAND_DESCRIPTIONS
+#define SCPI_CMD_DESC(S) (S),
+#else
+#define SCPI_CMD_DESC(S)
+#endif
+
+#if USE_COMMAND_TAGS
+#define SCPI_CMD_TAG(T) (T),
+#else
+#define SCPI_CMD_TAG(T)
+#endif
+
 const scpi_command_t scpi_commands[] = {
+    /* Optional help command */
+    {"HELP?", SCPI_HelpQ, SCPI_CMD_DESC("\t - list supported commands") SCPI_CMD_TAG(0)},
+	
     /* IEEE Mandated Commands (SCPI std V1999.0 4.1.1) */
-    {"*CLS", SCPI_CoreCls, 0},
-    {"*ESE", SCPI_CoreEse, 0},
-    {"*ESE?", SCPI_CoreEseQ, 0},
-    {"*ESR?", SCPI_CoreEsrQ, 0},
-    {"*IDN?", SCPI_CoreIdnQ, 0},
-    {"*OPC", SCPI_CoreOpc, 0},
-    {"*OPC?", SCPI_CoreOpcQ, 0},
-    {"*RST", SCPI_CoreRst, 0},
-    {"*SRE", SCPI_CoreSre, 0},
-    {"*SRE?", SCPI_CoreSreQ, 0},
-    {"*STB?", SCPI_CoreStbQ, 0},
-    {"*TST?", My_CoreTstQ, 0},
-    {"*WAI", SCPI_CoreWai, 0},
+    {"*CLS", SCPI_CoreCls, SCPI_CMD_TAG(0)},
+    {"*ESE", SCPI_CoreEse, SCPI_CMD_TAG(0)},
+    {"*ESE?", SCPI_CoreEseQ, SCPI_CMD_TAG(0)},
+    {"*ESR?", SCPI_CoreEsrQ, SCPI_CMD_TAG(0)},
+    {"*IDN?", SCPI_CoreIdnQ, SCPI_CMD_TAG(0)},
+    {"*OPC", SCPI_CoreOpc, SCPI_CMD_TAG(0)},
+    {"*OPC?", SCPI_CoreOpcQ, SCPI_CMD_TAG(0)},
+    {"*RST", SCPI_CoreRst, SCPI_CMD_TAG(0)},
+    {"*SRE", SCPI_CoreSre, SCPI_CMD_TAG(0)},
+    {"*SRE?", SCPI_CoreSreQ, SCPI_CMD_TAG(0)},
+    {"*STB?", SCPI_CoreStbQ, SCPI_CMD_TAG(0)},
+    {"*TST?", My_CoreTstQ, SCPI_CMD_TAG(0)},
+    {"*WAI", SCPI_CoreWai, SCPI_CMD_TAG(0)},
 
     /* Required SCPI commands (SCPI std V1999.0 4.2.1) */
-    {"SYSTem:ERRor[:NEXT]?", SCPI_SystemErrorNextQ, 0},
-    {"SYSTem:ERRor:COUNt?", SCPI_SystemErrorCountQ, 0},
-    {"SYSTem:VERSion?", SCPI_SystemVersionQ, 0},
+    {"SYSTem:ERRor[:NEXT]?", SCPI_SystemErrorNextQ, SCPI_CMD_TAG(0)},
+    {"SYSTem:ERRor:COUNt?", SCPI_SystemErrorCountQ, SCPI_CMD_TAG(0)},
+    {"SYSTem:VERSion?", SCPI_SystemVersionQ, SCPI_CMD_TAG(0)},
 
-    //{"STATus:OPERation?", scpi_stub_callback, 0},
-    //{"STATus:OPERation:EVENt?", scpi_stub_callback, 0},
-    //{"STATus:OPERation:CONDition?", scpi_stub_callback, 0},
-    //{"STATus:OPERation:ENABle", scpi_stub_callback, 0},
-    //{"STATus:OPERation:ENABle?", scpi_stub_callback, 0},
+    //{"STATus:OPERation?", scpi_stub_callback, SCPI_CMD_TAG(0)},
+    //{"STATus:OPERation:EVENt?", scpi_stub_callback, SCPI_CMD_TAG(0)},
+    //{"STATus:OPERation:CONDition?", scpi_stub_callback, SCPI_CMD_TAG(0)},
+    //{"STATus:OPERation:ENABle", scpi_stub_callback, SCPI_CMD_TAG(0)},
+    //{"STATus:OPERation:ENABle?", scpi_stub_callback, SCPI_CMD_TAG(0)},
 
-    {"STATus:QUEStionable[:EVENt]?", SCPI_StatusQuestionableEventQ, 0},
-    //{"STATus:QUEStionable:CONDition?", scpi_stub_callback, 0},
-    {"STATus:QUEStionable:ENABle", SCPI_StatusQuestionableEnable, 0},
-    {"STATus:QUEStionable:ENABle?", SCPI_StatusQuestionableEnableQ, 0},
+    {"STATus:QUEStionable[:EVENt]?", SCPI_StatusQuestionableEventQ, SCPI_CMD_TAG(0)},
+    //{"STATus:QUEStionable:CONDition?", scpi_stub_callback, SCPI_CMD_TAG(0)},
+    {"STATus:QUEStionable:ENABle", SCPI_StatusQuestionableEnable, SCPI_CMD_TAG(0)},
+    {"STATus:QUEStionable:ENABle?", SCPI_StatusQuestionableEnableQ, SCPI_CMD_TAG(0)},
 
-    {"STATus:PRESet", SCPI_StatusPreset, 0},
+    {"STATus:PRESet", SCPI_StatusPreset, SCPI_CMD_TAG(0)},
 
     /* DMM */
-    {"MEASure:VOLTage:DC?", DMM_MeasureVoltageDcQ, 0},
-    {"CONFigure:VOLTage:DC", DMM_ConfigureVoltageDc, 0},
-    {"MEASure:VOLTage:DC:RATio?", SCPI_StubQ, 0},
-    {"MEASure:VOLTage:AC?", DMM_MeasureVoltageAcQ, 0},
-    {"MEASure:CURRent:DC?", SCPI_StubQ, 0},
-    {"MEASure:CURRent:AC?", SCPI_StubQ, 0},
-    {"MEASure:RESistance?", SCPI_StubQ, 0},
-    {"MEASure:FRESistance?", SCPI_StubQ, 0},
-    {"MEASure:FREQuency?", SCPI_StubQ, 0},
-    {"MEASure:PERiod?", SCPI_StubQ, 0},
+    {"MEASure:VOLTage:DC?", DMM_MeasureVoltageDcQ, SCPI_CMD_TAG(0)},
+    {"CONFigure:VOLTage:DC", DMM_ConfigureVoltageDc, SCPI_CMD_TAG(0)},
+    {"MEASure:VOLTage:DC:RATio?", SCPI_StubQ, SCPI_CMD_TAG(0)},
+    {"MEASure:VOLTage:AC?", DMM_MeasureVoltageAcQ, SCPI_CMD_TAG(0)},
+    {"MEASure:CURRent:DC?", SCPI_StubQ, SCPI_CMD_TAG(0)},
+    {"MEASure:CURRent:AC?", SCPI_StubQ, SCPI_CMD_TAG(0)},
+    {"MEASure:RESistance?", SCPI_StubQ, SCPI_CMD_TAG(0)},
+    {"MEASure:FRESistance?", SCPI_StubQ, SCPI_CMD_TAG(0)},
+    {"MEASure:FREQuency?", SCPI_StubQ, SCPI_CMD_TAG(0)},
+    {"MEASure:PERiod?", SCPI_StubQ, SCPI_CMD_TAG(0)},
 
-    {"SYSTem:COMMunication:TCPIP:CONTROL?", SCPI_SystemCommTcpipControlQ, 0},
+    {"SYSTem:COMMunication:TCPIP:CONTROL?", SCPI_SystemCommTcpipControlQ, SCPI_CMD_TAG(0)},
 
-    {"TEST:BOOL", TEST_Bool, 0},
-    {"TEST:CHOice?", TEST_ChoiceQ, 0},
-    {"TEST#:NUMbers#", TEST_Numbers, 0},
-    {"TEST:TEXT", TEST_Text, 0},
-    {"TEST:ARBitrary?", TEST_ArbQ, 0},
-    {"TEST:CHANnellist", TEST_Chanlst, 0},
+    {"TEST:BOOL", TEST_Bool, SCPI_CMD_TAG(0)},
+    {"TEST:CHOice?", TEST_ChoiceQ, SCPI_CMD_TAG(0)},
+    {"TEST#:NUMbers#", TEST_Numbers, SCPI_CMD_TAG(0)},
+    {"TEST:TEXT", TEST_Text, SCPI_CMD_TAG(0)},
+    {"TEST:ARBitrary?", TEST_ArbQ, SCPI_CMD_TAG(0)},
+    {"TEST:CHANnellist", TEST_Chanlst, SCPI_CMD_TAG(0)},
 
     SCPI_CMD_LIST_END
 };

--- a/libscpi/inc/scpi/config.h
+++ b/libscpi/inc/scpi/config.h
@@ -49,9 +49,9 @@ extern "C" {
 #endif
 
 /* set the termination character(s)   */
-#define LINE_ENDING_CR          "\r"    /*   use a <CR> carriage return as termination charcter */
-#define LINE_ENDING_LF          "\n"    /*   use a <LF> line feed as termination charcter */
-#define LINE_ENDING_CRLF        "\r\n"  /*   use <CR><LF> carriage return + line feed as termination charcters */
+#define LINE_ENDING_CR          "\r"    /*   use a <CR> carriage return as termination character */
+#define LINE_ENDING_LF          "\n"    /*   use a <LF> line feed as termination character */
+#define LINE_ENDING_CRLF        "\r\n"  /*   use <CR><LF> carriage return + line feed as termination characters */
 
 #ifndef SCPI_LINE_ENDING
 #define SCPI_LINE_ENDING        LINE_ENDING_CRLF
@@ -59,7 +59,7 @@ extern "C" {
 
 /**
  * Detect, if it has limited resources or it is running on a full blown operating system.
- * All values can be overiden by scpi_user_config.h
+ * All values can be overridden by scpi_user_config.h
  */
 #define SYSTEM_BARE_METAL 0
 #define SYSTEM_FULL_BLOWN 1
@@ -76,8 +76,8 @@ extern "C" {
  * 0 = Minimal set of errors
  * 1 = Full set of errors
  *
- * For small systems, full set of errors will occupy large ammount of data
- * It is enabled by default on full blown systems and disabled on limited bare metal systems
+ * For small systems, full set of errors will occupy large amount of data.
+ * It is enabled by default on full blown systems and disabled on limited bare metal systems.
  */
 #ifndef USE_FULL_ERROR_LIST
 #define USE_FULL_ERROR_LIST SYSTEM_TYPE
@@ -174,14 +174,14 @@ extern "C" {
 #define USE_UNITS_ELECTRIC_CHARGE_CONDUCTANCE SYSTEM_TYPE
 #endif
 
-/* define local macros depending on existance of strnlen */
+/* define local macros depending on existence of strnlen */
 #if HAVE_STRNLEN
 #define SCPIDEFINE_strnlen(s, l)	strnlen((s), (l))
 #else
 #define SCPIDEFINE_strnlen(s, l)	BSD_strnlen((s), (l))
 #endif
 
-/* define local macros depending on existance of strncasecmp and strnicmp */
+/* define local macros depending on existence of strncasecmp and strnicmp */
 #if HAVE_STRNCASECMP
 #define SCPIDEFINE_strncasecmp(s1, s2, l) strncasecmp((s1), (s2), (l))
 #elif HAVE_STRNICMP

--- a/libscpi/inc/scpi/config.h
+++ b/libscpi/inc/scpi/config.h
@@ -110,6 +110,10 @@ extern "C" {
 #define USE_COMMAND_TAGS 1
 #endif
 
+#ifndef USE_COMMAND_DESCRIPTIONS
+#define USE_COMMAND_DESCRIPTIONS 1
+#endif
+
 #ifndef USE_DEPRECATED_FUNCTIONS
 #define USE_DEPRECATED_FUNCTIONS 1
 #endif

--- a/libscpi/inc/scpi/minimal.h
+++ b/libscpi/inc/scpi/minimal.h
@@ -59,7 +59,7 @@ extern "C" {
     scpi_result_t SCPI_StatusOperationEnableQ(scpi_t * context);
     scpi_result_t SCPI_StatusOperationEnable(scpi_t * context);
     scpi_result_t SCPI_StatusPreset(scpi_t * context);
-
+    scpi_result_t SCPI_HelpQ(scpi_t * context);
 
 #ifdef	__cplusplus
 }

--- a/libscpi/inc/scpi/types.h
+++ b/libscpi/inc/scpi/types.h
@@ -50,7 +50,7 @@
 extern "C" {
 #endif
 
-#if !HAVE_STDBOOL
+#if (!HAVE_STDBOOL) && (!_GLIBCXX_HAVE_STDBOOL_H)
     typedef unsigned char bool;
 #endif
 
@@ -354,7 +354,7 @@ extern "C" {
 #if USE_COMMAND_TAGS
         int32_t tag;
 #endif /* USE_COMMAND_TAGS */
-    };
+};
 
     struct _scpi_interface_t {
         scpi_error_callback_t error;
@@ -381,7 +381,7 @@ extern "C" {
         void * user_context;
         scpi_parser_state_t parser_state;
         const char * idn[4];
-        size_t arbitrary_reminding;
+        size_t arbitrary_remaining;
     };
 
     enum _scpi_array_format_t {

--- a/libscpi/inc/scpi/types.h
+++ b/libscpi/inc/scpi/types.h
@@ -114,10 +114,14 @@ extern "C" {
 
     typedef struct _scpi_command_t scpi_command_t;
 
-#if USE_COMMAND_TAGS
-	#define SCPI_CMD_LIST_END       {NULL, NULL, 0}
+#if USE_COMMAND_DESCRIPTIONS && USE_COMMAND_TAGS
+#define SCPI_CMD_LIST_END {NULL, NULL, NULL, 0}
+#elif USE_COMMAND_DESCRIPTIONS
+#define SCPI_CMD_LIST_END {NULL, NULL, NULL}
+#elif USE_COMMAND_TAGS
+#define SCPI_CMD_LIST_END {NULL, NULL, 0}
 #else
-	#define SCPI_CMD_LIST_END       {NULL, NULL}
+#define SCPI_CMD_LIST_END {NULL, NULL}
 #endif
 
 
@@ -351,6 +355,9 @@ extern "C" {
     struct _scpi_command_t {
         const char * pattern;
         scpi_command_callback_t callback;
+#if USE_COMMAND_DESCRIPTIONS
+        const char * description;
+#endif /* USE_COMMAND_DESCRIPTIONS */
 #if USE_COMMAND_TAGS
         int32_t tag;
 #endif /* USE_COMMAND_TAGS */

--- a/libscpi/src/minimal.c
+++ b/libscpi/src/minimal.c
@@ -213,3 +213,36 @@ scpi_result_t SCPI_StatusPreset(scpi_t * context) {
     SCPI_RegSet(context, SCPI_REG_QUES, 0);
     return SCPI_RES_OK;
 }
+
+/**
+ * HELP?
+ * @param context
+ * @return
+ */
+scpi_result_t SCPI_HelpQ(scpi_t * context) {
+    int i = 0;
+    for(;;) {
+        size_t pattern_len = strlen(context->cmdlist[i].pattern);
+        size_t block_len = 1 + pattern_len + strlen(SCPI_LINE_ENDING);
+#if USE_COMMAND_DESCRIPTIONS
+        size_t description_len = context->cmdlist[i].description ? strlen(context->cmdlist[i].description) : 0;
+        if(description_len > 0){
+            block_len = 1 + pattern_len + 1 + description_len + strlen(SCPI_LINE_ENDING);
+            }
+#endif
+        SCPI_ResultArbitraryBlockHeader(context, block_len);
+        SCPI_ResultArbitraryBlockData(context, "\t", 1);
+        SCPI_ResultArbitraryBlockData(context, context->cmdlist[i].pattern, pattern_len);
+#if USE_COMMAND_DESCRIPTIONS
+        if(description_len > 0){
+            SCPI_ResultArbitraryBlockData(context, " ", 1);
+            SCPI_ResultArbitraryBlockData(context, context->cmdlist[i].description, description_len);
+        }
+#endif
+        SCPI_ResultArbitraryBlockData(context, SCPI_LINE_ENDING, strlen(SCPI_LINE_ENDING));
+        if (context->cmdlist[++i].pattern == NULL) {
+            break;
+        }
+    }
+    return SCPI_RES_OK;
+}


### PR DESCRIPTION
Human-readability is often a welcome aspect when developing software for SCPI devices, but also valuable when testing configurations or debugging issues in a lab or test setup. Command syntax and parameter ranges are traditionally only documented in manuals or programmer's guides, but often control software allows sending raw commands and performing queries.

To both help people implementing and using systems based on scpi-parser and to help projects stand the test of time, it seems valuable for the device to be able to list its supported commands, preferably with a short description exposing expected parameter types and ranges.

This PR provides 
* SCPI_HelpQ() callback for a "HELP?" pattern and a
* USE_COMMAND_DESCRIPTIONS option which extends _scpi_command_t by a description string.

Data returned is formatted as an array of arbitrary block data. Newline characters are absorbed into the data of each block so the output is easily readable and can be parsed and displayed in control software (e.g. to provide a list of commands or syntax help).

Usage of the new features is demonstrated in the common example code.

![image](https://user-images.githubusercontent.com/24977335/152355792-d2c21cbd-b894-476c-b0ae-17f02b1b2c78.png)

The first column seen in the screenshot originates from the necessary block header information.

resolves #129