### PR TITLE
Add meson build-system support

### DIFF
--- a/examples/common-cxx/meson.build
+++ b/examples/common-cxx/meson.build
@@ -1,0 +1,8 @@
+libexample_commoncxx = static_library('common', 'scpi-def.cpp',
+  include_directories : [ inc, include_directories('.') ],
+)
+
+libexample_commoncxx_dep = declare_dependency(
+  include_directories : [ inc, include_directories('.') ],
+  link_with : libexample_commoncxx,
+)

--- a/examples/common/meson.build
+++ b/examples/common/meson.build
@@ -1,0 +1,8 @@
+libexample_common = static_library('common', 'scpi-def.c',
+  include_directories : [ inc, include_directories('.') ],
+)
+
+libexample_common_dep = declare_dependency(
+  include_directories : [ inc, include_directories('.') ],
+  link_with : libexample_common,
+)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,13 @@
+subdir('common')
+subdir('common-cxx')
+
+subdir('test-interactive')
+subdir('test-interactive-cxx')
+subdir('test-parser')
+
+subdir('test-tcp')
+subdir('test-tcp-srq')
+
+##subdir('test-CVI_w_GUI')
+##subdir('test-LwIP-netconn')
+subdir('test-vxi11')

--- a/examples/test-interactive-cxx/meson.build
+++ b/examples/test-interactive-cxx/meson.build
@@ -1,0 +1,1 @@
+executable('test-interactive', 'main.cpp', dependencies: [ libscpi_static_dep, libexample_commoncxx_dep ])

--- a/examples/test-interactive/meson.build
+++ b/examples/test-interactive/meson.build
@@ -1,0 +1,1 @@
+executable('test-interactive', 'main.c', dependencies: [ libscpi_static_dep, libexample_common_dep ])

--- a/examples/test-parser/meson.build
+++ b/examples/test-parser/meson.build
@@ -1,0 +1,1 @@
+executable('test-parser', 'main.c', dependencies: [ libscpi_static_dep, libexample_common_dep ])

--- a/examples/test-tcp-srq/meson.build
+++ b/examples/test-tcp-srq/meson.build
@@ -1,0 +1,1 @@
+executable('test-tcp-srq', 'main.c', dependencies: [ libscpi_static_dep, libexample_common_dep ])

--- a/examples/test-tcp/meson.build
+++ b/examples/test-tcp/meson.build
@@ -1,0 +1,1 @@
+executable('test-tcp', 'main.c', dependencies: [ libscpi_static_dep, libexample_common_dep ])

--- a/examples/test-vxi11/meson.build
+++ b/examples/test-vxi11/meson.build
@@ -1,0 +1,13 @@
+vxi11_dep = dependency('vxi11', required: false)
+tirpc_dep = dependency('libtirpc', required: false)
+
+if vxi11_dep.found() and tirpc_dep.found()
+  executable('test-vxi11',
+    [ 'main.c', 'vxi11_xdr.c' ],
+    dependencies: [
+      libscpi_static_dep,
+      libexample_common_dep,
+      tirpc_dep, vxi11_dep,
+    ]
+  )
+endif

--- a/libscpi/inc/meson.build
+++ b/libscpi/inc/meson.build
@@ -1,0 +1,18 @@
+inc = include_directories('.')
+
+headers = files([
+  'scpi/cc.h',
+  'scpi/config.h',
+  'scpi/constants.h',
+  'scpi/error.h',
+  'scpi/expression.h',
+  'scpi/ieee488.h',
+  'scpi/minimal.h',
+  'scpi/parser.h',
+  'scpi/scpi.h',
+  'scpi/types.h',
+  'scpi/units.h',
+  'scpi/utils.h',
+])
+
+install_headers(headers, subdir: 'scpi')

--- a/libscpi/meson.build
+++ b/libscpi/meson.build
@@ -1,0 +1,3 @@
+subdir('inc')
+subdir('src')
+subdir('test')

--- a/libscpi/src/meson.build
+++ b/libscpi/src/meson.build
@@ -1,0 +1,37 @@
+#  'scpi.g'
+sources = files([
+  'error.c',
+  'expression.c',
+  'fifo.c',
+  'ieee488.c',
+  'lexer.c',
+  'minimal.c',
+  'parser.c',
+  'units.c',
+  'utils.c',
+])
+
+inc_private = include_directories( '.' )
+
+libscpi = both_libraries('scpi',
+  sources,
+  soversion: meson.project_version(),
+  include_directories: [ inc, inc_private ],
+  install: true,
+)
+
+libscpi_dynamic_dep = declare_dependency(
+  include_directories: inc,
+  link_with: libscpi.get_shared_lib(),
+)
+
+libscpi_static_dep = declare_dependency(
+  include_directories: inc,
+  link_with: libscpi.get_static_lib(),
+)
+
+pkg = import('pkgconfig')
+pkg.generate(libscpi,
+  name: 'libscpi',
+  description : 'SCPI parser library',
+)

--- a/libscpi/test/meson.build
+++ b/libscpi/test/meson.build
@@ -1,0 +1,21 @@
+
+cunit_dep = dependency('cunit', required: false)
+if cunit_dep.found()
+  deps = [ libscpi_static_dep, cunit_dep ]
+
+  test('fifo',
+    executable('fifo', 'test_fifo.c', dependencies: deps)
+  )
+
+  test('lexer_parser',
+    executable('lexer_parser', 'test_lexer_parser.c', dependencies: deps)
+  )
+
+  test('parser',
+    executable('parser', 'test_parser.c', dependencies: deps)
+  )
+ 
+  test('scpi_utils',
+    executable('scpi_utils', 'test_scpi_utils.c', dependencies: deps)
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,20 @@
+project('scpi-parser', [ 'c', 'cpp' ],
+    version : '2.2',
+    license : 'BSD',
+    meson_version : '>= 0.60',
+    default_options : [
+      'warning_level=3',
+      'buildtype=debugoptimized',
+    ]
+  )
+
+
+c_args = []
+cpp_args = []
+
+cc = meson.get_compiler('c')
+
+install_data(files(['LICENSE', 'README.md']))
+
+subdir('libscpi')
+subdir('examples')


### PR DESCRIPTION
Although the Makefile works perfectly fine as it is right now, it is somewhat dated. Also it makes cross-compiling and packaging a bit tedious.

So this will allow to build the library and some of the examples with [meson](https://mesonbuild.com).