### PR TITLE
Add support for run-time configuration of the user errors and line en…

### DIFF
--- a/libscpi/inc/scpi/config.h
+++ b/libscpi/inc/scpi/config.h
@@ -54,7 +54,10 @@ extern "C" {
 #define LINE_ENDING_CRLF        "\r\n"  /*   use <CR><LF> carriage return + line feed as termination charcters */
 
 #ifndef SCPI_LINE_ENDING
+#ifndef USE_RUN_TIME_SCPI_LINE_ENDING
+#define USE_RUN_TIME_SCPI_LINE_ENDING 0
 #define SCPI_LINE_ENDING        LINE_ENDING_CRLF
+#endif
 #endif
 
 #ifndef USE_CUSTOM_REGISTERS
@@ -94,6 +97,15 @@ extern "C" {
  */
 #ifndef USE_USER_ERROR_LIST
 #define USE_USER_ERROR_LIST 0
+#endif
+
+/**
+ * Enable to use the run time error list in the interface
+ * 0 = Don't use the run time error list
+ * 1 = Use the run time error list
+ */
+#ifndef USE_RUN_TIME_USER_ERROR_LIST
+#define USE_RUN_TIME_USER_ERROR_LIST 0
 #endif
 
 #ifndef USE_DEVICE_DEPENDENT_ERROR_INFORMATION

--- a/libscpi/inc/scpi/error.h
+++ b/libscpi/inc/scpi/error.h
@@ -51,7 +51,11 @@ extern "C" {
     void SCPI_ErrorPushEx(scpi_t * context, int16_t err, char * info, size_t info_len);
     void SCPI_ErrorPush(scpi_t * context, int16_t err);
     int32_t SCPI_ErrorCount(scpi_t * context);
+#if !USE_RUN_TIME_USER_ERROR_LIST
     const char * SCPI_ErrorTranslate(int16_t err);
+#else
+    const char * SCPI_ErrorTranslate(scpi_t * context, int16_t err);
+#endif
 
 
     /* Using X-Macro technique to define everything once

--- a/libscpi/inc/scpi/types.h
+++ b/libscpi/inc/scpi/types.h
@@ -413,12 +413,25 @@ extern "C" {
 #endif /* USE_COMMAND_TAGS */
     };
 
+    typedef struct user_error_entry {
+        int val;
+        const char* str;
+    } user_error_entry;
+
+#define SCPI_RUN_TIME_USER_ERROR_LIST_END {0, NULL}
+
     struct _scpi_interface_t {
         scpi_error_callback_t error;
         scpi_write_t write;
         scpi_write_control_t control;
         scpi_command_callback_t flush;
         scpi_command_callback_t reset;
+#if USE_RUN_TIME_SCPI_LINE_ENDING
+        const char * line_ending;
+#endif
+#if USE_RUN_TIME_USER_ERROR_LIST
+        user_error_entry * user_error_list;
+#endif
     };
 
     struct _scpi_t {

--- a/libscpi/src/parser.c
+++ b/libscpi/src/parser.c
@@ -95,11 +95,15 @@ static size_t writeDelimiter(scpi_t * context) {
 static size_t writeNewLine(scpi_t * context) {
     if (!context->first_output) {
         size_t len;
+#if USE_RUN_TIME_SCPI_LINE_ENDING
+        len = writeData(context, context->interface->line_ending, strlen(context->interface->line_ending));
+#else
 #ifndef SCPI_LINE_ENDING
 #error no termination character defined
 #endif
         len = writeData(context, SCPI_LINE_ENDING, strlen(SCPI_LINE_ENDING));
-        flushData(context);
+#endif
+		flushData(context);
         return len;
     } else {
         return 0;
@@ -558,7 +562,11 @@ size_t SCPI_ResultError(scpi_t * context, scpi_error_t * error) {
     size_t len[SCPIDEFINE_DESCRIPTION_MAX_PARTS];
     size_t i;
 
+#if USE_RUN_TIME_USER_ERROR_LIST
+    data[0] = SCPI_ErrorTranslate(context, error->error_code);
+#else
     data[0] = SCPI_ErrorTranslate(error->error_code);
+#endif
     len[0] = strlen(data[0]);
 
 #if USE_DEVICE_DEPENDENT_ERROR_INFORMATION


### PR DESCRIPTION
This pull request introduces run-time configuration of the line ending and user errors. Run-time configuration is valuable when compiling the library as an independent archive or shared object and linking against it from different applications.

Minor modifications are applied to `_scpi_interface_t` in order to allow run time configuration, however, legacy compile time configuration is maintained using the following two macros (in `scpi_user_config.h`):
* `USE_RUN_TIME_SCPI_LINE_ENDING`
* `USE_RUN_TIME_USER_ERROR_LIST`