### PR TITLE
Add platformio library definition

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,24 @@
+{
+    "name": "scpi-parser",
+    "keywords": "scpi",
+    "version": "2.3-pre",
+    "description": "Open Source SCPI device library",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/j123b567/scpi-parser.git"
+    },
+    "authors": {
+        "name": "Jan Breuer",
+        "email": "jan.breuer@jaybee.cz"
+    },
+    "build": {
+        "includeDir": "libscpi/inc",
+        "srcDir": "libscpi/src"
+    },
+    "examples": [
+        "examples/test-interactive/main.c"
+    ],
+    "frameworks": "*",
+    "platforms": "*"
+}
+


### PR DESCRIPTION
This allows importing the scpi-parser library to platformio projects using this definition in platformio.ini:

    lib_deps = https://github.com/j123b567/scpi-parser.git

Without the library.json, platformio has trouble detecting the source code and include directories correctly.